### PR TITLE
ARCH-177: Python 3 support temporarily disabled.

### DIFF
--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -4,6 +4,6 @@ EdX utilities for Django Application development..
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 
 default_app_config = 'edx_django_utils.apps.EdxDjangoUtilsConfig'  # pylint: disable=invalid-name

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        # TODO: Restore Python 3
+        # 'Programming Language :: Python :: 3',
+        # 'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = {py27}-django{18,111}
+# TODO: Restore Python 3
 #envlist = {py27,py36}-django{18,111},py36-django20
 
 [doc8]


### PR DESCRIPTION
Removing Python 3 support for now to land this.  This was edx-platform Python 2.7 code to start.  Most of the Python 3 work was completed, but there is still some left.