### PR TITLE
Added function for caching users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - 3.6
 
 env:
-  - TOXENV=django18
   - TOXENV=django111
   - TOXENV=django20
 

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -4,6 +4,6 @@ EdX utilities for Django Application development..
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.0.3'
+__version__ = '1.1.0'
 
 default_app_config = 'edx_django_utils.apps.EdxDjangoUtilsConfig'  # pylint: disable=invalid-name

--- a/edx_django_utils/cache/__init__.py
+++ b/edx_django_utils/cache/__init__.py
@@ -3,9 +3,6 @@ Cache utilities public api
 
 See README.rst for details.
 """
+from __future__ import absolute_import, unicode_literals
 
-from .utils import (
-    DEFAULT_REQUEST_CACHE,
-    RequestCache,
-    TieredCache
-)
+from .utils import DEFAULT_REQUEST_CACHE, RequestCache, TieredCache, get_user

--- a/edx_django_utils/cache/middleware.py
+++ b/edx_django_utils/cache/middleware.py
@@ -1,6 +1,8 @@
 """
 Caching utility middleware.
 """
+from __future__ import absolute_import, unicode_literals
+
 from edx_django_utils.private_utils import _check_middleware_dependencies
 
 from . import RequestCache, TieredCache

--- a/edx_django_utils/cache/tests/test_middleware.py
+++ b/edx_django_utils/cache/tests/test_middleware.py
@@ -4,10 +4,13 @@ Tests for the RequestCacheMiddleware.
 """
 # pylint: disable=missing-docstring
 
+from __future__ import absolute_import, unicode_literals
+
 from django.test import RequestFactory, TestCase, override_settings
+from mock import MagicMock
+
 from edx_django_utils.cache import middleware
 from edx_django_utils.cache.utils import FORCE_CACHE_MISS_PARAM, SHOULD_FORCE_CACHE_MISS_KEY, RequestCache
-from mock import MagicMock
 
 TEST_KEY = "clobert"
 EXPECTED_VALUE = "bertclob"

--- a/edx_django_utils/monitoring/__init__.py
+++ b/edx_django_utils/monitoring/__init__.py
@@ -3,6 +3,7 @@ Metrics utilities public api
 
 See README.rst for details.
 """
+from __future__ import absolute_import, unicode_literals
 
 from .utils import (
     accumulate,
@@ -10,5 +11,5 @@ from .utils import (
     increment,
     set_custom_metric,
     set_custom_metrics_for_course_key,
-    set_monitoring_transaction_name,
+    set_monitoring_transaction_name
 )

--- a/edx_django_utils/monitoring/middleware.py
+++ b/edx_django_utils/monitoring/middleware.py
@@ -9,12 +9,15 @@ to report for this request, so it will not incur any processing overhead for
 request handlers which do not record custom metrics.
 
 """
+from __future__ import absolute_import, unicode_literals
+
 import logging
 from uuid import uuid4
 
 import psutil
 import waffle
 from django.utils import six
+
 from edx_django_utils.cache import RequestCache
 from edx_django_utils.private_utils import _check_middleware_dependencies
 
@@ -80,7 +83,7 @@ class MonitoringCustomMetricsMiddleware(object):
     # Whether or not there was an exception, report any custom NR metrics that
     # may have been collected.
 
-    def process_response(self, request, response):  # pylint: disable=unused-argument
+    def process_response(self, request, response):
         """
         Django middleware handler to process a response
         """

--- a/edx_django_utils/monitoring/tests/test_monitoring.py
+++ b/edx_django_utils/monitoring/tests/test_monitoring.py
@@ -1,10 +1,13 @@
 """
 Tests for monitoring custom metrics.
 """
+from __future__ import absolute_import, unicode_literals
+
 from django.test import TestCase, override_settings
+from mock import call, patch
+
 from edx_django_utils import monitoring
 from edx_django_utils.monitoring.middleware import MonitoringCustomMetricsMiddleware, MonitoringMemoryMiddleware
-from mock import call, patch
 
 
 class TestMonitoringCustomMetrics(TestCase):

--- a/edx_django_utils/monitoring/utils.py
+++ b/edx_django_utils/monitoring/utils.py
@@ -18,6 +18,8 @@ https://openedx.atlassian.net/wiki/display/PERF/Custom+Metrics+in+New+Relic
 At this time, these custom metrics will only be reported to New Relic.
 
 """
+from __future__ import absolute_import, unicode_literals
+
 from contextlib import contextmanager
 
 from django.utils import six

--- a/edx_django_utils/private_utils.py
+++ b/edx_django_utils/private_utils.py
@@ -6,6 +6,8 @@ edx-django-utils).  In some cases, these utilities could be elevated to public
 methods once they get some burn-in time and find a more permanent home in the
 library.
 """
+from __future__ import absolute_import, unicode_literals
+
 from django.conf import settings
 
 

--- a/edx_django_utils/tests/test_private_utils.py
+++ b/edx_django_utils/tests/test_private_utils.py
@@ -2,8 +2,10 @@
 Tests for the private utils.
 """
 # pylint: disable=missing-docstring
+from __future__ import absolute_import, unicode_literals
 
 from django.test import TestCase, override_settings
+
 from edx_django_utils.private_utils import _check_middleware_dependencies
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,8 +4,8 @@
 #
 #    make upgrade
 #
-django-waffle==0.14.0
-django==1.11.15
-newrelic==4.2.0.100
+django-waffle==0.15.1
+django==1.11.20
+newrelic==4.14.0.115
 psutil==1.2.1
-pytz==2018.5              # via django
+pytz==2018.9              # via django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,61 +5,72 @@
 #    make upgrade
 #
 argparse==1.4.0
-astroid==1.5.2
-atomicwrites==1.1.5
-attrs==18.1.0
+astroid==1.5.3
+atomicwrites==1.3.0
+attrs==19.1.0
 backports.functools-lru-cache==1.5
 caniusepython3==7.0.0
-certifi==2018.8.13
+certifi==2019.3.9
 chardet==3.0.4
 click-log==0.1.8
-click==6.7
+click==7.0
 codecov==2.0.15
-coverage==4.5.1
-diff-cover==1.0.4
-distlib==0.2.7
-django-waffle==0.14.0
-django==1.11.15
-edx-i18n-tools==0.4.7
-edx-lint==0.5.5
-first==2.0.1
-idna==2.7
-inflect==1.0.0            # via jinja2-pluralize
-isort==4.3.4
+configparser==3.7.3
+contextlib2==0.5.5        # via importlib-metadata
+coverage==4.5.3
+diff-cover==1.0.6
+distlib==0.2.8
+django-waffle==0.15.1
+django==1.11.20
+edx-i18n-tools==0.4.8
+edx-lint==1.1.1
+enum34==1.1.6
+filelock==3.0.10
+funcsigs==1.0.2
+futures==3.2.0 ; python_version < "3.6"
+idna==2.8
+importlib-metadata==0.8   # via path.py
+inflect==2.1.0            # via jinja2-pluralize
+isort==4.3.15
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10              # via diff-cover, jinja2-pluralize
 lazy-object-proxy==1.3.1
-markupsafe==1.0           # via jinja2
+markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1
 mock==2.0.0
-more-itertools==4.3.0
-newrelic==4.2.0.100
-packaging==17.1
-path.py==11.0.1           # via edx-i18n-tools
-pbr==4.2.0
-pip-tools==2.0.2
-pluggy==0.7.1
+more-itertools==5.0.0
+newrelic==4.14.0.115
+packaging==19.0
+path.py==11.5.0           # via edx-i18n-tools
+pathlib2==2.3.3
+pbr==5.1.3
+pip-tools==3.4.0
+pluggy==0.9.0
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
-py==1.5.4
-pycodestyle==2.4.0
-pydocstyle==2.1.1
-pygments==2.2.0           # via diff-cover
+py==1.8.0
+pycodestyle==2.5.0
+pydocstyle==3.0.0
+pygments==2.3.1           # via diff-cover
 pylint-celery==0.3
 pylint-django==0.7.2
-pylint-plugin-utils==0.4
-pylint==1.7.1
-pyparsing==2.2.0
-pytest-cov==2.5.1
-pytest-django==3.3.3
-pytest==3.7.1
-pytz==2018.5
+pylint-plugin-utils==0.5
+pylint==1.7.6
+pyparsing==2.3.1
+pytest-cov==2.6.1
+pytest-django==3.4.8
+pytest==4.3.0
+pytz==2018.9
 pyyaml==3.13              # via edx-i18n-tools
-requests==2.19.1
-six==1.11.0
+requests==2.21.0
+scandir==1.10.0
+singledispatch==3.4.0.3
+six==1.12.0
 snowballstemmer==1.2.1
+toml==0.10.0
 tox-battery==0.5.1
-tox==3.2.1
-urllib3==1.23
-virtualenv==16.0.0
-wrapt==1.10.11
+tox==3.7.0
+urllib3==1.24.1
+virtualenv==16.4.3
+wrapt==1.11.1
+zipp==0.3.3               # via importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,49 +4,48 @@
 #
 #    make upgrade
 #
-alabaster==0.7.11         # via sphinx
-atomicwrites==1.1.5
-attrs==18.1.0
+alabaster==0.7.12         # via sphinx
+atomicwrites==1.3.0
+attrs==19.1.0
 babel==2.6.0              # via sphinx
-bleach==2.1.3             # via readme-renderer
-certifi==2018.8.13        # via requests
-cffi==1.11.5              # via cmarkgfm
+bleach==3.1.0             # via readme-renderer
+certifi==2019.3.9         # via requests
 chardet==3.0.4            # via doc8, requests
-cmarkgfm==0.4.2           # via readme-renderer
-coverage==4.5.1
-django-waffle==0.14.0
-django==1.11.15
+coverage==4.5.3
+django-waffle==0.15.1
+django==1.11.20
 doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-sphinx-theme==1.3.0
-future==0.16.0            # via readme-renderer
-html5lib==1.0.1           # via bleach
-idna==2.7                 # via requests
-imagesize==1.0.0          # via sphinx
+edx-sphinx-theme==1.4.0
+funcsigs==1.0.2
+idna==2.8                 # via requests
+imagesize==1.1.0          # via sphinx
 jinja2==2.10              # via sphinx
-markupsafe==1.0           # via jinja2
+markupsafe==1.1.1         # via jinja2
 mock==2.0.0
-more-itertools==4.3.0
-newrelic==4.2.0.100
-packaging==17.1           # via sphinx
-pbr==4.2.0
-pluggy==0.7.1
+more-itertools==5.0.0
+newrelic==4.14.0.115
+packaging==19.0           # via sphinx
+pathlib2==2.3.3
+pbr==5.1.3
+pluggy==0.9.0
 psutil==1.2.1
-py==1.5.4
-pycparser==2.18           # via cffi
-pygments==2.2.0           # via readme-renderer, sphinx
-pyparsing==2.2.0          # via packaging
-pytest-cov==2.5.1
-pytest-django==3.3.3
-pytest==3.7.1
-pytz==2018.5
-readme-renderer==21.0
-requests==2.19.1          # via sphinx
-restructuredtext-lint==1.1.3  # via doc8
-six==1.11.0
+py==1.8.0
+pygments==2.3.1           # via readme-renderer, sphinx
+pyparsing==2.3.1          # via packaging
+pytest-cov==2.6.1
+pytest-django==3.4.8
+pytest==4.3.0
+pytz==2018.9
+readme-renderer==24.0
+requests==2.21.0          # via sphinx
+restructuredtext-lint==1.2.2  # via doc8
+scandir==1.10.0
+six==1.12.0
 snowballstemmer==1.2.1    # via sphinx
-sphinx==1.7.6
+sphinx==1.8.5
 sphinxcontrib-websupport==1.1.0  # via sphinx
-stevedore==1.29.0         # via doc8
-urllib3==1.23             # via requests
-webencodings==0.5.1       # via html5lib
+stevedore==1.30.1         # via doc8
+typing==3.6.6             # via sphinx
+urllib3==1.24.1           # via requests
+webencodings==0.5.1       # via bleach

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-click==6.7                # via pip-tools
-first==2.0.1              # via pip-tools
-pip-tools==2.0.2
-six==1.11.0               # via pip-tools
+click==7.0                # via pip-tools
+pip-tools==3.4.0
+six==1.12.0               # via pip-tools

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -2,6 +2,7 @@
 
 -r test.txt               # Core and testing dependencies for this package
 
+futures; python_version < '3.6'
 caniusepython3            # Additional Python 3 compatibility pylint checks
 edx-lint                  # edX pylint rules and plugins
 isort                     # to standardize order of imports

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -5,45 +5,52 @@
 #    make upgrade
 #
 argparse==1.4.0           # via caniusepython3
-astroid==1.5.2            # via edx-lint, pylint, pylint-celery
-atomicwrites==1.1.5
-attrs==18.1.0
-backports.functools-lru-cache==1.5  # via caniusepython3
+astroid==1.5.3            # via edx-lint, pylint, pylint-celery
+atomicwrites==1.3.0
+attrs==19.1.0
+backports.functools-lru-cache==1.5  # via astroid, caniusepython3, isort, pylint
 caniusepython3==7.0.0
-certifi==2018.8.13        # via requests
+certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 click-log==0.1.8          # via edx-lint
-click==6.7                # via click-log, edx-lint
-coverage==4.5.1
-distlib==0.2.7            # via caniusepython3
-django-waffle==0.14.0
-django==1.11.15
-edx-lint==0.5.5
-idna==2.7                 # via requests
-isort==4.3.4
+click==7.0                # via click-log, edx-lint
+configparser==3.7.3       # via pydocstyle, pylint
+coverage==4.5.3
+distlib==0.2.8            # via caniusepython3
+django-waffle==0.15.1
+django==1.11.20
+edx-lint==1.1.1
+enum34==1.1.6             # via astroid
+funcsigs==1.0.2
+futures==3.2.0 ; python_version < "3.6"
+idna==2.8                 # via requests
+isort==4.3.15
 lazy-object-proxy==1.3.1  # via astroid
 mccabe==0.6.1             # via pylint
 mock==2.0.0
-more-itertools==4.3.0
-newrelic==4.2.0.100
-packaging==17.1           # via caniusepython3
-pbr==4.2.0
-pluggy==0.7.1
+more-itertools==5.0.0
+newrelic==4.14.0.115
+packaging==19.0           # via caniusepython3
+pathlib2==2.3.3
+pbr==5.1.3
+pluggy==0.9.0
 psutil==1.2.1
-py==1.5.4
-pycodestyle==2.4.0
-pydocstyle==2.1.1
+py==1.8.0
+pycodestyle==2.5.0
+pydocstyle==3.0.0
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.4  # via pylint-celery, pylint-django
-pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.2.0          # via packaging
-pytest-cov==2.5.1
-pytest-django==3.3.3
-pytest==3.7.1
-pytz==2018.5
-requests==2.19.1          # via caniusepython3
-six==1.11.0
+pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
+pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pyparsing==2.3.1          # via packaging
+pytest-cov==2.6.1
+pytest-django==3.4.8
+pytest==4.3.0
+pytz==2018.9
+requests==2.21.0          # via caniusepython3
+scandir==1.10.0
+singledispatch==3.4.0.3   # via astroid, pylint
+six==1.12.0
 snowballstemmer==1.2.1    # via pydocstyle
-urllib3==1.23             # via requests
-wrapt==1.10.11            # via astroid
+urllib3==1.24.1           # via requests
+wrapt==1.11.1             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,19 +4,22 @@
 #
 #    make upgrade
 #
-atomicwrites==1.1.5       # via pytest
-attrs==18.1.0             # via pytest
-coverage==4.5.1           # via pytest-cov
-django-waffle==0.14.0
+atomicwrites==1.3.0       # via pytest
+attrs==19.1.0             # via pytest
+coverage==4.5.3           # via pytest-cov
+django-waffle==0.15.1
+funcsigs==1.0.2           # via mock, pytest
 mock==2.0.0
-more-itertools==4.3.0     # via pytest
-newrelic==4.2.0.100
-pbr==4.2.0                # via mock
-pluggy==0.7.1             # via pytest
+more-itertools==5.0.0     # via pytest
+newrelic==4.14.0.115
+pathlib2==2.3.3           # via pytest, pytest-django
+pbr==5.1.3                # via mock
+pluggy==0.9.0             # via pytest
 psutil==1.2.1
-py==1.5.4                 # via pytest
-pytest-cov==2.5.1
-pytest-django==3.3.3
-pytest==3.7.1             # via pytest-cov, pytest-django
-pytz==2018.5
-six==1.11.0               # via mock, more-itertools, pytest
+py==1.8.0                 # via pytest
+pytest-cov==2.6.1
+pytest-django==3.4.8
+pytest==4.3.0             # via pytest-cov, pytest-django
+pytz==2018.9
+scandir==1.10.0           # via pathlib2
+six==1.12.0               # via mock, more-itertools, pathlib2, pytest

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,18 +4,21 @@
 #
 #    make upgrade
 #
-certifi==2018.8.13        # via requests
+certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
-coverage==4.5.1           # via codecov
-idna==2.7                 # via requests
+coverage==4.5.3           # via codecov
+filelock==3.0.10          # via tox
+funcsigs==1.0.2           # via mock
+idna==2.8                 # via requests
 mock==2.0.0
-pbr==4.2.0                # via mock
-pluggy==0.7.1             # via tox
-py==1.5.4                 # via tox
-requests==2.19.1          # via codecov
-six==1.11.0               # via mock, tox
+pbr==5.1.3                # via mock
+pluggy==0.9.0             # via tox
+py==1.8.0                 # via tox
+requests==2.21.0          # via codecov
+six==1.12.0               # via mock, tox
+toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.2.1
-urllib3==1.23             # via requests
-virtualenv==16.0.0        # via tox
+tox==3.7.0
+urllib3==1.24.1           # via requests
+virtualenv==16.4.3        # via tox

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@
 # -*- coding: utf-8 -*-
 # Note: pylint disable of useless-suppression is required because the errors
 # are different for python 2.7 and python 3.6.
-# pylint: disable=C0111,W6100,useless-suppression
+# pylint: disable=C0111,W6005,W6100,useless-suppression
 """
 Package metadata for edx-django-utils.
 """
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import re


### PR DESCRIPTION
**Description:**

This adds a utility function -- `get_user(user_id)` that will store user objects in the request cache.
I noticed a lot of instances in edx-platform and elsewhere of `User.objects.get(id=user_id)`, likely looking up the same user several times in one request. 

I'd be happy to make this a more generic function (cache any model), if necessary.


**JIRA:**

[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)

**Dependencies:**

List dependencies on other outstanding PRs, issues, etc.

**Merge deadline:**

List merge deadline (if any)

**Installation instructions:**

List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] @edx/arch-review
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
