### PR TITLE
Fixed documentation and test name using force_cache_miss

### DIFF
--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -4,6 +4,6 @@ EdX utilities for Django Application development..
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.0.3'
+__version__ = '1.0.4'
 
 default_app_config = 'edx_django_utils.apps.EdxDjangoUtilsConfig'  # pylint: disable=invalid-name

--- a/edx_django_utils/cache/README.rst
+++ b/edx_django_utils/cache/README.rst
@@ -108,13 +108,13 @@ Force Django Cache Miss
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 To force recompute a value stored in the django cache, add the query
-parameter 'force_django_cache_miss'. This will force a CACHE_MISS.
+parameter 'force_cache_miss'. This will force a CACHE_MISS.
 
 This requires staff permissions.
 
 Example::
 
-    http://clobert.com/api/v1/resource?force_django_cache_miss=true
+    http://clobert.com/api/v1/resource?force_cache_miss=true
 
 
 CachedResponse

--- a/edx_django_utils/cache/middleware.py
+++ b/edx_django_utils/cache/middleware.py
@@ -47,7 +47,7 @@ class TieredCacheMiddleware(object):
 
     def process_request(self, request):
         """
-        Stores whether or not FORCE_DJANGO_CACHE_MISS_KEY was supplied in the
+        Stores whether or not FORCE_CACHE_MISS_PARAM was supplied in the
         request.
         """
         TieredCache._get_and_set_force_cache_miss(request)  # pylint: disable=protected-access

--- a/edx_django_utils/cache/tests/test_middleware.py
+++ b/edx_django_utils/cache/tests/test_middleware.py
@@ -74,7 +74,7 @@ class TestTieredCacheMiddleware(TestCase):
 
         self.assertFalse(self.request_cache.get_cached_response(SHOULD_FORCE_CACHE_MISS_KEY).value)
 
-    def test_process_request_force_django_cache_miss(self):
+    def test_process_request_force_cache_miss(self):
         request = RequestFactory().get('/?{}=tRuE'.format(FORCE_CACHE_MISS_PARAM))
         request.user = self._mock_user(is_staff=True)
 
@@ -82,7 +82,7 @@ class TestTieredCacheMiddleware(TestCase):
 
         self.assertTrue(self.request_cache.get_cached_response(SHOULD_FORCE_CACHE_MISS_KEY).value)
 
-    def test_process_request_force_django_cache_miss_non_staff(self):
+    def test_process_request_force_cache_miss_non_staff(self):
         request = RequestFactory().get('/?{}=tRuE'.format(FORCE_CACHE_MISS_PARAM))
         request.user = self._mock_user(is_staff=False)
 

--- a/edx_django_utils/cache/tests/test_utils.py
+++ b/edx_django_utils/cache/tests/test_utils.py
@@ -167,7 +167,7 @@ class TestTieredCache(TestCase):
         self.assertTrue(cached_response.is_found, 'Django cache hit should cache value in request cache.')
 
     @mock.patch('django.core.cache.cache.get')
-    def test_get_cached_response_force_django_cache_miss(self, mock_cache_get):
+    def test_get_cached_response_force_cache_miss(self, mock_cache_get):
         self.request_cache.set(SHOULD_FORCE_CACHE_MISS_KEY, True)
         mock_cache_get.return_value = EXPECTED_VALUE
         cached_response = TieredCache.get_cached_response(TEST_KEY)


### PR DESCRIPTION
**Description:**

Fixed documentation and test name using force_cache_miss

**JIRA:**

[WL-1914](https://openedx.atlassian.net/browse/WL-1914)

**Dependencies:**

List dependencies on other outstanding PRs, issues, etc.

**Merge deadline:**

List merge deadline (if any)

**Installation instructions:**

List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] @edx/arch-review
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
