### PR TITLE
run make upgrade to update jinja2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,10 +21,11 @@ import re
 import sys
 from subprocess import check_call
 
-import edx_theme
 from django import setup as django_setup
 from django.conf import settings
 from django.utils import six
+
+import edx_theme
 
 
 def get_version(*file_paths):

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -4,6 +4,6 @@ EdX utilities for Django Application development..
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.0.4'
+__version__ = '1.0.5'
 
 default_app_config = 'edx_django_utils.apps.EdxDjangoUtilsConfig'  # pylint: disable=invalid-name

--- a/edx_django_utils/cache/__init__.py
+++ b/edx_django_utils/cache/__init__.py
@@ -4,8 +4,4 @@ Cache utilities public api
 See README.rst for details.
 """
 
-from .utils import (
-    DEFAULT_REQUEST_CACHE,
-    RequestCache,
-    TieredCache
-)
+from .utils import DEFAULT_REQUEST_CACHE, RequestCache, TieredCache

--- a/edx_django_utils/cache/tests/test_middleware.py
+++ b/edx_django_utils/cache/tests/test_middleware.py
@@ -5,9 +5,10 @@ Tests for the RequestCacheMiddleware.
 # pylint: disable=missing-docstring
 
 from django.test import RequestFactory, TestCase, override_settings
+from mock import MagicMock
+
 from edx_django_utils.cache import middleware
 from edx_django_utils.cache.utils import FORCE_CACHE_MISS_PARAM, SHOULD_FORCE_CACHE_MISS_KEY, RequestCache
-from mock import MagicMock
 
 TEST_KEY = "clobert"
 EXPECTED_VALUE = "bertclob"

--- a/edx_django_utils/cache/tests/test_utils.py
+++ b/edx_django_utils/cache/tests/test_utils.py
@@ -8,6 +8,7 @@ from threading import Thread
 from unittest import TestCase
 
 import mock
+
 from edx_django_utils.cache.utils import (
     DEFAULT_REQUEST_CACHE_NAMESPACE,
     SHOULD_FORCE_CACHE_MISS_KEY,
@@ -28,6 +29,7 @@ TEST_DJANGO_TIMEOUT_CACHE = 1
 
 class TestRequestCache(TestCase):
     def setUp(self):
+        super(TestRequestCache, self).setUp()
         RequestCache.clear_all_namespaces()
         self.request_cache = RequestCache()
         self.other_request_cache = RequestCache(TEST_NAMESPACE)
@@ -143,6 +145,7 @@ class TestRequestCache(TestCase):
 
 class TestTieredCache(TestCase):
     def setUp(self):
+        super(TestTieredCache, self).setUp()
         self.request_cache = RequestCache()
         TieredCache.dangerous_clear_all_tiers()
 
@@ -244,8 +247,8 @@ class CacheResponseTests(TestCase):
         )
 
     def test_cached_response_not_equals(self):
-        self.assertTrue(
-            CachedResponse(True, TEST_KEY, EXPECTED_VALUE) != CachedResponse(True, TEST_KEY, EXPECTED_VALUE_2)
+        self.assertNotEqual(
+            CachedResponse(True, TEST_KEY, EXPECTED_VALUE), CachedResponse(True, TEST_KEY, EXPECTED_VALUE_2)
         )
 
     def test_cached_response_misuse(self):

--- a/edx_django_utils/monitoring/__init__.py
+++ b/edx_django_utils/monitoring/__init__.py
@@ -10,5 +10,5 @@ from .utils import (
     increment,
     set_custom_metric,
     set_custom_metrics_for_course_key,
-    set_monitoring_transaction_name,
+    set_monitoring_transaction_name
 )

--- a/edx_django_utils/monitoring/middleware.py
+++ b/edx_django_utils/monitoring/middleware.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 import psutil
 import waffle
 from django.utils import six
+
 from edx_django_utils.cache import RequestCache
 from edx_django_utils.private_utils import _check_middleware_dependencies
 
@@ -80,7 +81,7 @@ class MonitoringCustomMetricsMiddleware(object):
     # Whether or not there was an exception, report any custom NR metrics that
     # may have been collected.
 
-    def process_response(self, request, response):  # pylint: disable=unused-argument
+    def process_response(self, request, response):
         """
         Django middleware handler to process a response
         """

--- a/edx_django_utils/monitoring/tests/test_monitoring.py
+++ b/edx_django_utils/monitoring/tests/test_monitoring.py
@@ -2,9 +2,10 @@
 Tests for monitoring custom metrics.
 """
 from django.test import TestCase, override_settings
+from mock import call, patch
+
 from edx_django_utils import monitoring
 from edx_django_utils.monitoring.middleware import MonitoringCustomMetricsMiddleware, MonitoringMemoryMiddleware
-from mock import call, patch
 
 
 class TestMonitoringCustomMetrics(TestCase):

--- a/edx_django_utils/tests/test_private_utils.py
+++ b/edx_django_utils/tests/test_private_utils.py
@@ -4,6 +4,7 @@ Tests for the private utils.
 # pylint: disable=missing-docstring
 
 from django.test import TestCase, override_settings
+
 from edx_django_utils.private_utils import _check_middleware_dependencies
 
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,7 @@
 # Core requirements for using this application
 
+-c constraints.txt
+
 Django>=1.8,<2.0          # Web application framework
 django-waffle             # Allows for feature toggles in Django.
 newrelic                  # New Relic agent for performance monitoring

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,8 +4,8 @@
 #
 #    make upgrade
 #
-django-waffle==0.14.0
-django==1.11.15
-newrelic==4.2.0.100
+django-waffle==0.16.0
+django==1.11.20
+newrelic==4.20.0.120
 psutil==1.2.1
-pytz==2018.5              # via django
+pytz==2019.1              # via django

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 django-waffle==0.16.0
-django==1.11.20
+django==1.11.21
 newrelic==4.20.0.120
 psutil==1.2.1
 pytz==2019.1              # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,0 +1,12 @@
+# Version constraints for pip-installation.
+#
+# This file doesn't install any packages. It specifies version constraints
+# that will be applied if a package is needed.
+#
+# When pinning something here, please provide an explanation of why.  Ideally,
+# link to other information that will help people in the future to remove the
+# pin when possible.  Writing an issue against the offending project and
+# linking to it here is good.
+
+ # These packages are backports which can only be installed on Python 2.7
+futures ; python_version == "2.7"

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,6 @@
 # Additional requirements for development of this application
 
+-c constraints.txt
 -r pip-tools.txt          # pip-tools and its dependencies, for managing requirements files
 -r quality.txt            # Core and quality check dependencies
 -r travis.txt             # tox and related dependencies

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,16 +18,16 @@ codecov==2.0.15
 configparser==3.7.4
 contextlib2==0.5.5
 coverage==4.5.3
-diff-cover==2.0.1
+diff-cover==2.1.0
 distlib==0.2.9.post0
 django-waffle==0.16.0
-django==1.11.20
+django==1.11.21
 edx-i18n-tools==0.4.8
-edx-lint==1.2.1
+edx-lint==1.3.0
 enum34==1.1.6
 filelock==3.0.12
 funcsigs==1.0.2
-futures==3.2.0
+futures==3.2.0 ; python_version == "2.7"
 idna==2.8
 importlib-metadata==0.17
 inflect==2.1.0            # via jinja2-pluralize
@@ -43,7 +43,7 @@ newrelic==4.20.0.120
 packaging==19.0
 path.py==11.5.2           # via edx-i18n-tools
 pathlib2==2.3.3
-pip-tools==3.7.0
+pip-tools==3.8.0
 pluggy==0.12.0
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
@@ -57,10 +57,10 @@ pylint-plugin-utils==0.5
 pylint==1.7.6
 pyparsing==2.4.0
 pytest-cov==2.7.1
-pytest-django==3.4.8
-pytest==4.5.0
+pytest-django==3.5.0
+pytest==4.6.2
 pytz==2019.1
-pyyaml==5.1               # via edx-i18n-tools
+pyyaml==5.1.1             # via edx-i18n-tools
 requests==2.22.0
 scandir==1.10.0
 singledispatch==3.4.0.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,61 +5,72 @@
 #    make upgrade
 #
 argparse==1.4.0
-astroid==1.5.2
-atomicwrites==1.1.5
-attrs==18.1.0
+astroid==1.5.3
+atomicwrites==1.3.0
+attrs==19.1.0
 backports.functools-lru-cache==1.5
-caniusepython3==7.0.0
-certifi==2018.8.13
+caniusepython3==7.1.0
+certifi==2019.3.9
 chardet==3.0.4
-click-log==0.1.8
-click==6.7
+click-log==0.3.2
+click==7.0
 codecov==2.0.15
-coverage==4.5.1
-diff-cover==1.0.4
-distlib==0.2.7
-django-waffle==0.14.0
-django==1.11.15
-edx-i18n-tools==0.4.7
-edx-lint==0.5.5
-first==2.0.1
-idna==2.7
-inflect==1.0.0            # via jinja2-pluralize
-isort==4.3.4
+configparser==3.7.4
+contextlib2==0.5.5
+coverage==4.5.3
+diff-cover==2.0.1
+distlib==0.2.9.post0
+django-waffle==0.16.0
+django==1.11.20
+edx-i18n-tools==0.4.8
+edx-lint==1.2.1
+enum34==1.1.6
+filelock==3.0.12
+funcsigs==1.0.2
+futures==3.2.0
+idna==2.8
+importlib-metadata==0.17
+inflect==2.1.0            # via jinja2-pluralize
+isort==4.3.20
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.10              # via diff-cover, jinja2-pluralize
-lazy-object-proxy==1.3.1
-markupsafe==1.0           # via jinja2
+jinja2==2.10.1            # via diff-cover, jinja2-pluralize
+lazy-object-proxy==1.4.1
+markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1
-mock==2.0.0
-more-itertools==4.3.0
-newrelic==4.2.0.100
-packaging==17.1
-path.py==11.0.1           # via edx-i18n-tools
-pbr==4.2.0
-pip-tools==2.0.2
-pluggy==0.7.1
+mock==3.0.5
+more-itertools==5.0.0
+newrelic==4.20.0.120
+packaging==19.0
+path.py==11.5.2           # via edx-i18n-tools
+pathlib2==2.3.3
+pip-tools==3.7.0
+pluggy==0.12.0
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
-py==1.5.4
-pycodestyle==2.4.0
-pydocstyle==2.1.1
-pygments==2.2.0           # via diff-cover
+py==1.8.0
+pycodestyle==2.5.0
+pydocstyle==3.0.0
+pygments==2.4.2           # via diff-cover
 pylint-celery==0.3
 pylint-django==0.7.2
-pylint-plugin-utils==0.4
-pylint==1.7.1
-pyparsing==2.2.0
-pytest-cov==2.5.1
-pytest-django==3.3.3
-pytest==3.7.1
-pytz==2018.5
-pyyaml==3.13              # via edx-i18n-tools
-requests==2.19.1
-six==1.11.0
+pylint-plugin-utils==0.5
+pylint==1.7.6
+pyparsing==2.4.0
+pytest-cov==2.7.1
+pytest-django==3.4.8
+pytest==4.5.0
+pytz==2019.1
+pyyaml==5.1               # via edx-i18n-tools
+requests==2.22.0
+scandir==1.10.0
+singledispatch==3.4.0.3
+six==1.12.0
 snowballstemmer==1.2.1
+toml==0.10.0
 tox-battery==0.5.1
-tox==3.2.1
-urllib3==1.23
-virtualenv==16.0.0
-wrapt==1.10.11
+tox==3.12.1
+urllib3==1.25.3
+virtualenv==16.6.0
+wcwidth==0.1.7
+wrapt==1.11.1
+zipp==0.5.1

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -1,5 +1,6 @@
 # Requirements for documentation validation
 
+-c constraints.txt
 -r test.txt               # Core and testing dependencies for this package
 
 doc8                      # reStructuredText style checker

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -15,7 +15,7 @@ configparser==3.7.4
 contextlib2==0.5.5
 coverage==4.5.3
 django-waffle==0.16.0
-django==1.11.20
+django==1.11.21
 doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-sphinx-theme==1.4.0
@@ -28,17 +28,17 @@ markupsafe==1.1.1         # via jinja2
 mock==3.0.5
 more-itertools==5.0.0
 newrelic==4.20.0.120
-packaging==19.0           # via sphinx
+packaging==19.0
 pathlib2==2.3.3
 pbr==5.2.1                # via stevedore
 pluggy==0.12.0
 psutil==1.2.1
 py==1.8.0
 pygments==2.4.2           # via readme-renderer, sphinx
-pyparsing==2.4.0          # via packaging
+pyparsing==2.4.0
 pytest-cov==2.7.1
-pytest-django==3.4.8
-pytest==4.5.0
+pytest-django==3.5.0
+pytest==4.6.2
 pytz==2019.1
 readme-renderer==24.0
 requests==2.22.0          # via sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,49 +4,53 @@
 #
 #    make upgrade
 #
-alabaster==0.7.11         # via sphinx
-atomicwrites==1.1.5
-attrs==18.1.0
-babel==2.6.0              # via sphinx
-bleach==2.1.3             # via readme-renderer
-certifi==2018.8.13        # via requests
-cffi==1.11.5              # via cmarkgfm
+alabaster==0.7.12         # via sphinx
+atomicwrites==1.3.0
+attrs==19.1.0
+babel==2.7.0              # via sphinx
+bleach==3.1.0             # via readme-renderer
+certifi==2019.3.9         # via requests
 chardet==3.0.4            # via doc8, requests
-cmarkgfm==0.4.2           # via readme-renderer
-coverage==4.5.1
-django-waffle==0.14.0
-django==1.11.15
+configparser==3.7.4
+contextlib2==0.5.5
+coverage==4.5.3
+django-waffle==0.16.0
+django==1.11.20
 doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-sphinx-theme==1.3.0
-future==0.16.0            # via readme-renderer
-html5lib==1.0.1           # via bleach
-idna==2.7                 # via requests
-imagesize==1.0.0          # via sphinx
-jinja2==2.10              # via sphinx
-markupsafe==1.0           # via jinja2
-mock==2.0.0
-more-itertools==4.3.0
-newrelic==4.2.0.100
-packaging==17.1           # via sphinx
-pbr==4.2.0
-pluggy==0.7.1
+edx-sphinx-theme==1.4.0
+funcsigs==1.0.2
+idna==2.8                 # via requests
+imagesize==1.1.0          # via sphinx
+importlib-metadata==0.17
+jinja2==2.10.1            # via sphinx
+markupsafe==1.1.1         # via jinja2
+mock==3.0.5
+more-itertools==5.0.0
+newrelic==4.20.0.120
+packaging==19.0           # via sphinx
+pathlib2==2.3.3
+pbr==5.2.1                # via stevedore
+pluggy==0.12.0
 psutil==1.2.1
-py==1.5.4
-pycparser==2.18           # via cffi
-pygments==2.2.0           # via readme-renderer, sphinx
-pyparsing==2.2.0          # via packaging
-pytest-cov==2.5.1
-pytest-django==3.3.3
-pytest==3.7.1
-pytz==2018.5
-readme-renderer==21.0
-requests==2.19.1          # via sphinx
-restructuredtext-lint==1.1.3  # via doc8
-six==1.11.0
+py==1.8.0
+pygments==2.4.2           # via readme-renderer, sphinx
+pyparsing==2.4.0          # via packaging
+pytest-cov==2.7.1
+pytest-django==3.4.8
+pytest==4.5.0
+pytz==2019.1
+readme-renderer==24.0
+requests==2.22.0          # via sphinx
+restructuredtext-lint==1.3.0  # via doc8
+scandir==1.10.0
+six==1.12.0
 snowballstemmer==1.2.1    # via sphinx
-sphinx==1.7.6
-sphinxcontrib-websupport==1.1.0  # via sphinx
-stevedore==1.29.0         # via doc8
-urllib3==1.23             # via requests
-webencodings==0.5.1       # via html5lib
+sphinx==1.8.5
+sphinxcontrib-websupport==1.1.2  # via sphinx
+stevedore==1.30.1         # via doc8
+typing==3.6.6             # via sphinx
+urllib3==1.25.3           # via requests
+wcwidth==0.1.7
+webencodings==0.5.1       # via bleach
+zipp==0.5.1

--- a/requirements/pip-tools.in
+++ b/requirements/pip-tools.in
@@ -1,3 +1,4 @@
 # Just the dependencies to run pip-tools, mainly for the "upgrade" make target
 
+-c constraints.txt
 pip-tools                 # Contains pip-compile, used to generate pip requirements files

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-click==6.7                # via pip-tools
-first==2.0.1              # via pip-tools
-pip-tools==2.0.2
-six==1.11.0               # via pip-tools
+click==7.0                # via pip-tools
+pip-tools==3.7.0
+six==1.12.0               # via pip-tools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==3.7.0
+pip-tools==3.8.0
 six==1.12.0               # via pip-tools

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -1,5 +1,6 @@
 # Requirements for code quality checks
 
+-c constraints.txt
 -r test.txt               # Core and testing dependencies for this package
 
 caniusepython3            # Additional Python 3 compatibility pylint checks

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -19,11 +19,11 @@ contextlib2==0.5.5
 coverage==4.5.3
 distlib==0.2.9.post0      # via caniusepython3
 django-waffle==0.16.0
-django==1.11.20
-edx-lint==1.2.1
+django==1.11.21
+edx-lint==1.3.0
 enum34==1.1.6             # via astroid
 funcsigs==1.0.2
-futures==3.2.0            # via caniusepython3, isort
+futures==3.2.0 ; python_version == "2.7"  # via caniusepython3, isort
 idna==2.8                 # via requests
 importlib-metadata==0.17
 isort==4.3.20
@@ -32,7 +32,7 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==5.0.0
 newrelic==4.20.0.120
-packaging==19.0           # via caniusepython3
+packaging==19.0
 pathlib2==2.3.3
 pluggy==0.12.0
 psutil==1.2.1
@@ -43,10 +43,10 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.4.0          # via packaging
+pyparsing==2.4.0
 pytest-cov==2.7.1
-pytest-django==3.4.8
-pytest==4.5.0
+pytest-django==3.5.0
+pytest==4.6.2
 pytz==2019.1
 requests==2.22.0          # via caniusepython3
 scandir==1.10.0

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -5,45 +5,55 @@
 #    make upgrade
 #
 argparse==1.4.0           # via caniusepython3
-astroid==1.5.2            # via edx-lint, pylint, pylint-celery
-atomicwrites==1.1.5
-attrs==18.1.0
-backports.functools-lru-cache==1.5  # via caniusepython3
-caniusepython3==7.0.0
-certifi==2018.8.13        # via requests
+astroid==1.5.3            # via pylint, pylint-celery
+atomicwrites==1.3.0
+attrs==19.1.0
+backports.functools-lru-cache==1.5  # via astroid, caniusepython3, isort, pylint
+caniusepython3==7.1.0
+certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
-click-log==0.1.8          # via edx-lint
-click==6.7                # via click-log, edx-lint
-coverage==4.5.1
-distlib==0.2.7            # via caniusepython3
-django-waffle==0.14.0
-django==1.11.15
-edx-lint==0.5.5
-idna==2.7                 # via requests
-isort==4.3.4
-lazy-object-proxy==1.3.1  # via astroid
+click-log==0.3.2          # via edx-lint
+click==7.0                # via click-log, edx-lint
+configparser==3.7.4
+contextlib2==0.5.5
+coverage==4.5.3
+distlib==0.2.9.post0      # via caniusepython3
+django-waffle==0.16.0
+django==1.11.20
+edx-lint==1.2.1
+enum34==1.1.6             # via astroid
+funcsigs==1.0.2
+futures==3.2.0            # via caniusepython3, isort
+idna==2.8                 # via requests
+importlib-metadata==0.17
+isort==4.3.20
+lazy-object-proxy==1.4.1  # via astroid
 mccabe==0.6.1             # via pylint
-mock==2.0.0
-more-itertools==4.3.0
-newrelic==4.2.0.100
-packaging==17.1           # via caniusepython3
-pbr==4.2.0
-pluggy==0.7.1
+mock==3.0.5
+more-itertools==5.0.0
+newrelic==4.20.0.120
+packaging==19.0           # via caniusepython3
+pathlib2==2.3.3
+pluggy==0.12.0
 psutil==1.2.1
-py==1.5.4
-pycodestyle==2.4.0
-pydocstyle==2.1.1
+py==1.8.0
+pycodestyle==2.5.0
+pydocstyle==3.0.0
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.4  # via pylint-celery, pylint-django
-pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.2.0          # via packaging
-pytest-cov==2.5.1
-pytest-django==3.3.3
-pytest==3.7.1
-pytz==2018.5
-requests==2.19.1          # via caniusepython3
-six==1.11.0
+pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
+pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pyparsing==2.4.0          # via packaging
+pytest-cov==2.7.1
+pytest-django==3.4.8
+pytest==4.5.0
+pytz==2019.1
+requests==2.22.0          # via caniusepython3
+scandir==1.10.0
+singledispatch==3.4.0.3   # via astroid, pylint
+six==1.12.0
 snowballstemmer==1.2.1    # via pydocstyle
-urllib3==1.23             # via requests
-wrapt==1.10.11            # via astroid
+urllib3==1.25.3           # via requests
+wcwidth==0.1.7
+wrapt==1.11.1             # via astroid
+zipp==0.5.1

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,5 +1,6 @@
 # Requirements for test runs.
 
+-c constraints.txt
 -r base.txt               # Core dependencies for this package
 
 mock                      # Backport of unittest.mock, available in Python 3.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,19 +11,21 @@ contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.3           # via pytest-cov
 django-waffle==0.16.0
 funcsigs==1.0.2           # via mock, pytest
-importlib-metadata==0.17  # via pluggy
+importlib-metadata==0.17  # via pluggy, pytest
 mock==3.0.5
 more-itertools==5.0.0     # via pytest
 newrelic==4.20.0.120
+packaging==19.0           # via pytest
 pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
 pluggy==0.12.0            # via pytest
 psutil==1.2.1
 py==1.8.0                 # via pytest
+pyparsing==2.4.0          # via packaging
 pytest-cov==2.7.1
-pytest-django==3.4.8
-pytest==4.5.0             # via pytest-cov, pytest-django
+pytest-django==3.5.0
+pytest==4.6.2             # via pytest-cov, pytest-django
 pytz==2019.1
 scandir==1.10.0           # via pathlib2
-six==1.12.0               # via mock, pathlib2, pytest
+six==1.12.0               # via mock, packaging, pathlib2, pytest
 wcwidth==0.1.7            # via pytest
 zipp==0.5.1               # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,19 +4,26 @@
 #
 #    make upgrade
 #
-atomicwrites==1.1.5       # via pytest
-attrs==18.1.0             # via pytest
-coverage==4.5.1           # via pytest-cov
-django-waffle==0.14.0
-mock==2.0.0
-more-itertools==4.3.0     # via pytest
-newrelic==4.2.0.100
-pbr==4.2.0                # via mock
-pluggy==0.7.1             # via pytest
+atomicwrites==1.3.0       # via pytest
+attrs==19.1.0             # via pytest
+configparser==3.7.4       # via importlib-metadata
+contextlib2==0.5.5        # via importlib-metadata
+coverage==4.5.3           # via pytest-cov
+django-waffle==0.16.0
+funcsigs==1.0.2           # via mock, pytest
+importlib-metadata==0.17  # via pluggy
+mock==3.0.5
+more-itertools==5.0.0     # via pytest
+newrelic==4.20.0.120
+pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
+pluggy==0.12.0            # via pytest
 psutil==1.2.1
-py==1.5.4                 # via pytest
-pytest-cov==2.5.1
-pytest-django==3.3.3
-pytest==3.7.1             # via pytest-cov, pytest-django
-pytz==2018.5
-six==1.11.0               # via mock, more-itertools, pytest
+py==1.8.0                 # via pytest
+pytest-cov==2.7.1
+pytest-django==3.4.8
+pytest==4.5.0             # via pytest-cov, pytest-django
+pytz==2019.1
+scandir==1.10.0           # via pathlib2
+six==1.12.0               # via mock, pathlib2, pytest
+wcwidth==0.1.7            # via pytest
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/travis.in
+++ b/requirements/travis.in
@@ -1,5 +1,7 @@
 # Requirements for running tests in Travis
 
+-c constraints.txt
+
 codecov                   # Code coverage reporting
 mock                      # Backport of unittest.mock, available in Python 3.3
 tox                       # Virtualenv management for tests

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,18 +4,26 @@
 #
 #    make upgrade
 #
-certifi==2018.8.13        # via requests
+certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
-coverage==4.5.1           # via codecov
-idna==2.7                 # via requests
-mock==2.0.0
-pbr==4.2.0                # via mock
-pluggy==0.7.1             # via tox
-py==1.5.4                 # via tox
-requests==2.19.1          # via codecov
-six==1.11.0               # via mock, tox
+configparser==3.7.4       # via importlib-metadata
+contextlib2==0.5.5        # via importlib-metadata
+coverage==4.5.3           # via codecov
+filelock==3.0.12          # via tox
+funcsigs==1.0.2           # via mock
+idna==2.8                 # via requests
+importlib-metadata==0.17  # via pluggy
+mock==3.0.5
+pathlib2==2.3.3           # via importlib-metadata
+pluggy==0.12.0            # via tox
+py==1.8.0                 # via tox
+requests==2.22.0          # via codecov
+scandir==1.10.0           # via pathlib2
+six==1.12.0               # via mock, pathlib2, tox
+toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.2.1
-urllib3==1.23             # via requests
-virtualenv==16.0.0        # via tox
+tox==3.12.1
+urllib3==1.25.3           # via requests
+virtualenv==16.6.0        # via tox
+zipp==0.5.1               # via importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ def is_requirement(line):
         line.startswith('-r') or
         line.startswith('#') or
         line.startswith('-e') or
-        line.startswith('git+')
+        line.startswith('git+') or
+        line.startswith('-c')
     )
 
 


### PR DESCRIPTION
**Description:** 

This PR updates the jinja2 version. Please see PROD-343 for more information.

**JIRA:**

[PROD-343](https://openedx.atlassian.net/browse/PROD-343)

**Dependencies:**

List dependencies on other outstanding PRs, issues, etc.

**Merge deadline:**

List merge deadline (if any)

**Installation instructions:**

List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] @edx/arch-review
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
