### PR TITLE
Support Django 1.10 style middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - 3.6
 
 env:
-  - TOXENV=django18
   - TOXENV=django111
   - TOXENV=django20
 
@@ -23,7 +22,7 @@ matrix:
 
 cache:
   - pip
-  
+
 before_install:
   - pip install --upgrade pip
 
@@ -39,7 +38,7 @@ after_success:
 deploy:
   provider: pypi
   user: edx
-  password: 
+  password:
     secure: S3YrdGTgH3AXDN5EzMVLqyUvp/RvPc8lVo3Z5KrU3P9E87cjWyBUI+jVUk38lBUkO06n9ACbWt44f7H6n2GQeKCf6ZUZa69QgxXPRQZP+XiEGwtlv2YgatqeqNG7y6WTp3261mJ5kXuEcKBak7uNpru3gazEUxgc1EtbrsNPVS3oMChyIsi3j3KJuAq+h0AHibx1XMgWToU9aCbmrznjs18dXPmu+VhXyqJGliz79zxn5mvSZjCFOYwZtie/uD/g7+4V5wk75aDAfr4GYTbvvIvuDxyopZsaSRUB89aNWlpKKbOlsL5DuJWSkcY2I31tAQ3z3FtIJPKBFC44N81jwk+JdD4APq1qzeu3DMO+O8xJbUi8VZ6QgWiU17WnIFff0s9sTtmBdDRZAfx5XR4kqMLiVADSeR2XNfivP7/57LgEog0p0zrS2VnSbvvvk1lxfLxxwr3qk0DubP5SqgtqCrBfj/C5/iz5gg24c56kzfvf0BWF1vleez2Se/zQlICODpaT+Jf/2kPKFaaM3vwAKnCR/wD+Q9p6B1Dq8eb2ZRs4ucEkAuJtGfaKZrNUInt6h1bF7StnjyaXZnZWRbBRLMudoFEVOLg5pbEZiktYNuZWleYU120YUoz6O1mZOjt/FzPgXOu5o1tHN8OdcDWaEIzAO78LrIKAf6vqMtTavDM=
   distributions: sdist bdist_wheel
   on:

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -4,6 +4,6 @@ EdX utilities for Django Application development..
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.0.5'
+__version__ = '2.0.0'
 
 default_app_config = 'edx_django_utils.apps.EdxDjangoUtilsConfig'  # pylint: disable=invalid-name

--- a/edx_django_utils/cache/README.rst
+++ b/edx_django_utils/cache/README.rst
@@ -96,7 +96,7 @@ This middleware should come after the RequestCacheMiddleware. Additionally,
 since this functionality checks for staff permissions, it should come after any
 authentication middleware.  Here is an example::
 
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE = (
         'edx_django_utils.cache.middleware.RequestCacheMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         ...
@@ -135,7 +135,7 @@ An example of the Bug::
         # calculated value is None, set None in cache, and return value.
         # BUG: None will be treated as a cache miss every time.
     return  cache_value
-    
+
 Future Ideas
 ------------
 

--- a/edx_django_utils/cache/middleware.py
+++ b/edx_django_utils/cache/middleware.py
@@ -1,12 +1,14 @@
 """
 Caching utility middleware.
 """
+from django.utils.deprecation import MiddlewareMixin
+
 from edx_django_utils.private_utils import _check_middleware_dependencies
 
 from . import RequestCache, TieredCache
 
 
-class RequestCacheMiddleware(object):
+class RequestCacheMiddleware(MiddlewareMixin):
     """
     Middleware to clear the request cache as appropriate for new requests.
     """
@@ -31,12 +33,12 @@ class RequestCacheMiddleware(object):
         return None
 
 
-class TieredCacheMiddleware(object):
+class TieredCacheMiddleware(MiddlewareMixin):
     """
     Middleware to store whether or not to force django cache misses.
     """
-    def __init__(self):
-        super(TieredCacheMiddleware, self).__init__()
+    def __init__(self, get_response=None):
+        super(TieredCacheMiddleware, self).__init__(get_response=get_response)
         # checks proper dependency order as well.
         _check_middleware_dependencies(self, required_middleware=[
             'edx_django_utils.cache.middleware.RequestCacheMiddleware',

--- a/edx_django_utils/monitoring/README.rst
+++ b/edx_django_utils/monitoring/README.rst
@@ -8,7 +8,7 @@ Here is how you add the middleware::
 
 .. code-block::
 
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE = (
         'edx_django_utils.cache.middleware.RequestCacheMiddleware',
         ...
         # Monitoring middleware must come after RequestCacheMiddleware

--- a/edx_django_utils/monitoring/middleware.py
+++ b/edx_django_utils/monitoring/middleware.py
@@ -35,7 +35,7 @@ class MonitoringCustomMetricsMiddleware(object):
     """
     The middleware class for adding custom metrics.
 
-    Make sure to add below the request cache in MIDDLEWARE_CLASSES.
+    Make sure to add below the request cache in MIDDLEWARE.
     """
 
     def __init__(self):
@@ -100,7 +100,7 @@ class MonitoringMemoryMiddleware(object):
     """
     Middleware for monitoring memory usage.
 
-    Make sure to add below the request cache in MIDDLEWARE_CLASSES.
+    Make sure to add below the request cache in MIDDLEWARE.
     """
     memory_data_key = u'memory_data'
     guid_key = u'guid_key'

--- a/edx_django_utils/private_utils.py
+++ b/edx_django_utils/private_utils.py
@@ -31,12 +31,12 @@ def _check_middleware_dependencies(concerned_object, required_middleware):
 
     Raises:
         AssertionError if the provided dependencies don't appear in
-            MIDDLEWARE_CLASSES in the correct order.
+            MIDDLEWARE in the correct order.
 
     """
     declared_middleware = getattr(settings, 'MIDDLEWARE', None)
     if declared_middleware is None:
-        declared_middleware = settings.MIDDLEWARE_CLASSES  # Django 1.8 support
+        declared_middleware = settings.MIDDLEWARE_CLASSES  # Pre-Django 2 support
 
     # Filter out all the middleware except the ones we care about for ordering.
     matching_middleware = [mw for mw in declared_middleware if mw in required_middleware]

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,7 @@
 
 -c constraints.txt
 
-Django>=1.8,<2.0          # Web application framework
+Django>=1.11,<2.0          # Web application framework
 django-waffle             # Allows for feature toggles in Django.
 newrelic                  # New Relic agent for performance monitoring
 psutil==1.2.1             # Library for retrieving information on running processes and system utilization

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,6 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,6 @@ norecursedirs = .* docs requirements
 
 [testenv]
 deps =
-    django18: Django>=1.8,<1.9
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     -r{toxinidir}/requirements/test.txt


### PR DESCRIPTION
In Django 1.10, a new middleware style was introduced, that uses a MIDDLEWARE setting rather than MIDDLEWARE_CLASSES.

In Django 2, only the new style will be supported.

This change allows our middleware to be used both ways, but drops support for Django 1.8.

This package claims to support Django 2, but the current middleware classes can't work with Django 2, right? Was that ever tried?

If Django 1.8 support is important to maintain, I can do an optional import situation and keep support. But I figured the open edx ecosystem is on 1.11+.

**Reviewers:**
- [ ] @edx/arch-review
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)