### PR TITLE
Fix function tracing for New Relic Agent 5.0.0.124

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Change Log
    in this file.  It adheres to the structure of http://keepachangelog.com/ ,
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
-   
+
    This project adheres to Semantic Versioning (http://semver.org/).
 
 .. There should always be an "Unreleased" section for changes pending release.
@@ -14,6 +14,23 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 *
+
+[2.0.1] - 2019-10-09
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Changed
+_______
+
+* Fixed: Updated function tracing to accomodate changes in New Relic's 5.x Agent.
+
+[2.0.0] - 2019-07-07
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Changed
+_______
+
+* Converted Middleware (from old style MIDDLEWARE_CLASSES to MIDDLEWARE).
+* Removed support for Django versions < 1.11
 
 [1.0.1] - 2018-09-07
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -4,6 +4,6 @@ EdX utilities for Django Application development..
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 default_app_config = 'edx_django_utils.apps.EdxDjangoUtilsConfig'  # pylint: disable=invalid-name

--- a/edx_django_utils/monitoring/utils.py
+++ b/edx_django_utils/monitoring/utils.py
@@ -105,9 +105,17 @@ def function_trace(function_name):
     Wraps a chunk of code that we want to appear as a separate, explicit,
     segment in our monitoring tools.
     """
-    if newrelic:
-        nr_transaction = newrelic.agent.current_transaction()
-        with newrelic.agent.FunctionTrace(nr_transaction, function_name):
-            yield
+    # Not covering this because if we mock it, we're not really testing anything
+    # anyway. If something did break, it should show up in tests for apps that
+    # use this code with newrelic enabled, on whatever version of newrelic they
+    # run.
+    if newrelic:  # pragma: no cover
+        if newrelic.version_info[0] >= 5:
+            with newrelic.agent.FunctionTrace(function_name):
+                yield
+        else:
+            nr_transaction = newrelic.agent.current_transaction()
+            with newrelic.agent.FunctionTrace(nr_transaction, function_name):
+                yield
     else:
         yield


### PR DESCRIPTION
Version 5.0.0.124 of the New Relic Agent changed the function tracing
API. Using it the old way was resulting in many thousands of new metrics
being added (each process invocation of a function trace was creating a
new metric name), so we ended up with a bunch of "metrics" named like:

determine_group_permissions/<newrelic.api.web_transaction.WSGIWebTransaction object at 0x7f09bf016ad0>
determine_group_permissions/<newrelic.api.web_transaction.WSGIWebTransaction object at 0x7f09bf098510>
determine_group_permissions/<newrelic.api.web_transaction.WSGIWebTransaction object at 0x7f09bf0a8bd0>
determine_group_permissions/<newrelic.api.web_transaction.WSGIWebTransaction object at 0x7f09bf108b50>
determine_group_permissions/<newrelic.api.web_transaction.WSGIWebTransaction object at 0x7f09bf112250>

See: https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-500124

**Description:**

Describe in a couple of sentence what this PR adds

**JIRA:**

[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)

**Dependencies:**

List dependencies on other outstanding PRs, issues, etc.

**Merge deadline:**

List merge deadline (if any)

**Installation instructions:**

List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] @edx/arch-review
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
