### PR TITLE
clarify RequestCacheMiddleware requirement

### DIFF
--- a/edx_django_utils/cache/README.rst
+++ b/edx_django_utils/cache/README.rst
@@ -10,38 +10,25 @@ RequestCache
 
 A thread-local for storing request scoped cache values.
 
-An optional namespace can be used with the RequestCache, or you can use
-the `DEFAULT_REQUEST_CACHE`.
+An optional namespace can be used with the RequestCache, or you can use the `DEFAULT_REQUEST_CACHE`.
 
 RequestCacheMiddleware
 ----------------------
 
-You must include 'edx_django_utils.cache.middleware.RequestCacheMiddleware'
-when using the RequestCache to ensure it is emptied between requests. This
-should be added before most middleware, in case any other middleware wants
-to use the request cache.
+You must include 'edx_django_utils.cache.middleware.RequestCacheMiddleware' when using the RequestCache to ensure it is emptied between requests. This should be added before most middleware, in case any other middleware wants to use the request cache.
 
 Note: This middleware may just be a safety net, but safe is good.
 
 TieredCache
 -----------
 
-The first tier is the default request cache that is tied to the life of a
-given request. The second tier is the Django cache -- e.g. the "default"
-entry in settings.CACHES, typically backed by memcached.
+The first tier is the default request cache that is tied to the life of a given request. The second tier is the Django cache -- e.g. the "default" entry in settings.CACHES, typically backed by memcached.
 
 Some baseline rules:
 
-1. Treat it as a global namespace, like any other cache. The per-request
-   local cache is only going to live for the lifetime of one request, but
-   the backing cache is going to be something like Memcached, where key
-   collision is possible.
+1. Treat it as a global namespace, like any other cache. The per-request local cache is only going to live for the lifetime of one request, but the backing cache is going to be something like Memcached, where key collision is possible.
 
-2. Timeouts are ignored for the purposes of the in-memory request cache,
-   but do apply to the Django cache. One consequence of this is that
-   sending an explicit timeout of 0 in `set_all_tiers` will cause that
-   item to only be cached across the duration of the request and will not
-   cause a write to the remote cache.
+2. Timeouts are ignored for the purposes of the in-memory request cache, but do apply to the Django cache. One consequence of this is that sending an explicit timeout of 0 in `set_all_tiers` will cause that item to only be cached across the duration of the request and will not cause a write to the remote cache.
 
 Sample Usage (cache hit)::
 
@@ -60,16 +47,11 @@ Sample Usage (cache miss)::
 Warning when storing bools
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**Warning**: When storing a bool in a TieredCache that uses Memcached,
-`Memcached will return an int`_. However, the RequestCache will return a
-bool. Therefore, the first time a bool is set the TieredCache will return a
-bool and in later requests the TieredCache will return an int.
+**Warning**: When storing a bool in a TieredCache that uses Memcached, `Memcached will return an int`_. However, the RequestCache will return a bool. Therefore, the first time a bool is set the TieredCache will return a bool and in later requests the TieredCache will return an int.
 
-Where possible, you can ensure a consistent return value by storing
-``int(my_bool)`` rather than ``my_bool``.
+Where possible, you can ensure a consistent return value by storing ``int(my_bool)`` rather than ``my_bool``.
 
-Additionally, when checking the value, do the following check that works
-for ints::
+Additionally, when checking the value, do the following check that works for ints::
 
     # do this.
     if my_bool_cached_response.is_found:
@@ -88,13 +70,9 @@ Do **not** explictly test against ``True`` or ``False``::
 TieredCacheMiddleware
 ---------------------
 
-You must include 'edx_django_utils.cache.middleware.TieredCacheMiddleware'
-when using the TieredCache if you want to enable the `Force Django Cache Miss`_
-functionality.
+You must include 'edx_django_utils.cache.middleware.TieredCacheMiddleware' when using the TieredCache if you want to enable the `Force Django Cache Miss`_ functionality.
 
-This middleware should come after the RequestCacheMiddleware. Additionally,
-since this functionality checks for staff permissions, it should come after any
-authentication middleware.  Here is an example::
+This middleware should come after the required RequestCacheMiddleware, which the TieredCache needs because it uses RequestCache internally. Additionally, since this functionality checks for staff permissions, it should come after any authentication middleware.  Here is an example::
 
     MIDDLEWARE = (
         'edx_django_utils.cache.middleware.RequestCacheMiddleware',
@@ -107,8 +85,7 @@ authentication middleware.  Here is an example::
 Force Django Cache Miss
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-To force recompute a value stored in the django cache, add the query
-parameter 'force_cache_miss'. This will force a CACHE_MISS.
+To force recompute a value stored in the django cache, add the query parameter 'force_cache_miss'. This will force a CACHE_MISS.
 
 This requires staff permissions.
 
@@ -120,12 +97,9 @@ Example::
 CachedResponse
 --------------
 
-A CachedResponse includes the cache miss/hit status (is_found) and the value
-stored in the cache (for cache hits).
+A CachedResponse includes the cache miss/hit status (is_found) and the value stored in the cache (for cache hits).
 
-The purpose of the CachedResponse is to avoid a common bug with the default
-Django cache interface where a cache hit that is Falsey (e.g. None) is
-misinterpreted as a cache miss.
+The purpose of the CachedResponse is to avoid a common bug with the default Django cache interface where a cache hit that is Falsey (e.g. None) is misinterpreted as a cache miss.
 
 An example of the Bug::
 
@@ -139,7 +113,6 @@ An example of the Bug::
 Future Ideas
 ------------
 
-* See `ARCH-240`_ for a discussion of additional cache utilities that could
-  be made available.
+* See `ARCH-240`_ for a discussion of additional cache utilities that could be made available.
 
 .. _ARCH-240: https://openedx.atlassian.net/browse/ARCH-240


### PR DESCRIPTION
**Description:**

* Only a single line had a significant text change, which is clarifying that RequestCacheMiddleware is required by the TieredCache.  See https://github.com/edx/edx-django-utils/pull/29/files#r364262397
* The rest of the changes were removing hard-wraps to comply with the documentation OEP.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)