### PR TITLE
Add tooling for working with the read-replica database.

### DIFF
--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -4,7 +4,7 @@ EdX utilities for Django Application development..
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '3.0'
+__version__ = "3.1"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -6,4 +6,6 @@ from __future__ import absolute_import, unicode_literals
 
 __version__ = '3.0'
 
-default_app_config = 'edx_django_utils.apps.EdxDjangoUtilsConfig'  # pylint: disable=invalid-name
+default_app_config = (
+    "edx_django_utils.apps.EdxDjangoUtilsConfig"
+)

--- a/edx_django_utils/cache/tests/test_middleware.py
+++ b/edx_django_utils/cache/tests/test_middleware.py
@@ -2,7 +2,6 @@
 """
 Tests for the RequestCacheMiddleware.
 """
-# pylint: disable=missing-docstring
 from django.test import RequestFactory, TestCase, override_settings
 from mock import MagicMock
 
@@ -14,7 +13,7 @@ EXPECTED_VALUE = "bertclob"
 TEST_NAMESPACE = "test_namespace"
 
 
-class TestRequestCacheMiddleware(TestCase):
+class TestRequestCacheMiddleware(TestCase):  # pylint: disable=missing-class-docstring
 
     @override_settings(MIDDLEWARE=['edx_django_utils.cache.middleware.RequestCacheMiddleware'])
     def setUp(self):
@@ -55,7 +54,7 @@ class TestRequestCacheMiddleware(TestCase):
         self.other_request_cache.set(TEST_KEY, EXPECTED_VALUE)
 
 
-class TestTieredCacheMiddleware(TestCase):
+class TestTieredCacheMiddleware(TestCase):  # pylint: disable=missing-class-docstring
 
     @override_settings(MIDDLEWARE=[
         'edx_django_utils.cache.middleware.RequestCacheMiddleware',

--- a/edx_django_utils/cache/tests/test_utils.py
+++ b/edx_django_utils/cache/tests/test_utils.py
@@ -2,7 +2,6 @@
 """
 Tests for the request cache.
 """
-# pylint: disable=missing-docstring
 
 from threading import Thread
 from unittest import TestCase
@@ -27,8 +26,7 @@ TEST_NAMESPACE = u"test_namespåce"
 TEST_DJANGO_TIMEOUT_CACHE = 1
 
 
-class TestRequestCache(TestCase):
-
+class TestRequestCache(TestCase):  # pylint: disable=missing-class-docstring
     def setUp(self):
         super(TestRequestCache, self).setUp()
         RequestCache.clear_all_namespaces()
@@ -144,8 +142,7 @@ class TestRequestCache(TestCase):
             RequestCache(DEFAULT_REQUEST_CACHE_NAMESPACE)
 
 
-class TestTieredCache(TestCase):
-
+class TestTieredCache(TestCase):  # pylint: disable=missing-class-docstring
     def setUp(self):
         super(TestTieredCache, self).setUp()
         self.request_cache = RequestCache()
@@ -205,8 +202,7 @@ class TestTieredCache(TestCase):
         mock_cache_delete.assert_called_with(TEST_KEY)
 
 
-class CacheResponseTests(TestCase):
-
+class CacheResponseTests(TestCase):  # pylint: disable=missing-class-docstring
     def test_is_miss(self):
         is_found = False
         cached_response = CachedResponse(is_found, TEST_KEY, EXPECTED_VALUE)

--- a/edx_django_utils/db/__init__.py
+++ b/edx_django_utils/db/__init__.py
@@ -1,0 +1,13 @@
+"""
+Utilities for working effectively with databases in django.
+
+read_replica: Tools for making queries from the read-replica.
+"""
+
+from .read_replica import (
+    ReadReplicaRouter,
+    read_queries_only,
+    read_replica_or_default,
+    use_read_replica_if_available,
+    write_queries
+)

--- a/edx_django_utils/db/read_replica.py
+++ b/edx_django_utils/db/read_replica.py
@@ -1,0 +1,157 @@
+"""
+Tools for making queries read from the read-replica database, rather than from the writer database.
+
+The read-replica can be used for
+    a. long-running queries that aren't time sensitive
+    b. reads of rows that are frequently written, but where reads can be eventually consistent
+
+Settings:
+    EDX_READ_REPLICA_DB_NAME: The name of the read-replica in the DATABASES django setting.
+        Defaults to "read_replica".
+    EDX_WRITER_DB_NAME: The name of the writer in the DATABASES django setting.
+        Defaults to "default".
+"""
+import threading
+from contextlib import contextmanager
+
+from django.conf import settings
+
+READ_REPLICA_NAME = getattr(settings, "EDX_READ_REPLICA_DB_NAME", "read_replica")
+WRITER_NAME = getattr(settings, "EDX_WRITER_DB_NAME", "default")
+
+READ_REPLICA_OR_DEFAULT = (
+    READ_REPLICA_NAME if READ_REPLICA_NAME in settings.DATABASES else WRITER_NAME
+)
+
+
+def use_read_replica_if_available(queryset):
+    """
+    If there is a database called 'read_replica',
+    use that database for the queryset / manager.
+
+    Example usage:
+        queryset = use_read_replica_if_available(SomeModel.objects.filter(...))
+
+    Arguments:
+        queryset (QuerySet)
+
+    Returns: QuerySet
+    """
+    return queryset.using(READ_REPLICA_OR_DEFAULT)
+
+
+def read_replica_or_default():
+    """
+    If there is a database called READ_REPLICA_DB,
+    return READ_REPLICA_DB, otherwise return WRITER_NAME.
+
+    This function is similiar to `use_read_replica_if_available`,
+    but is be more syntactically convenient for method call chaining.
+    Also, it always falls back to WRITER_NAME,
+    no matter what the queryset was using before.
+
+    Example usage:
+        queryset = SomeModel.objects.filter(...).using(read_replica_or_default())
+
+    Returns: str
+    """
+    return READ_REPLICA_OR_DEFAULT
+
+
+@contextmanager
+def read_queries_only():
+    """
+    A context manager that sets all reads inside it to be from the read-replica.
+
+    It is an error to call this from inside a write_queries context.
+
+    The ReadReplicaRouter must be used for this decorator to affect queries.
+    """
+    old_db_name = _storage.db_name
+    assert (
+        old_db_name is None or old_db_name == READ_REPLICA_NAME
+    ), "Can't use read_queries_only inside a write_queries contextmanager"
+    _storage.db_name = READ_REPLICA_NAME
+    try:
+        yield
+    finally:
+        _storage.db_name = old_db_name
+
+
+@contextmanager
+def write_queries():
+    """
+    A context manager that sets all reads inside it to be from the writer.
+    Use this to annotate code that has both reads and writes, where the writes depend
+    on the values read. This will allow all of that code to exist within a transaction.
+
+    Using this contextmanager will prevent any contained call from using `read_queries_only`
+    in order to read from the read-replica.
+
+    It is an error to call this from inside a read_queries_only context.
+
+    The ReadReplicaRouter must be used for this decorator to affect queries.
+    """
+    old_db_name = _storage.db_name
+    assert (
+        old_db_name is None or old_db_name == WRITER_NAME
+    ), "Can't use write_queries inside a read_only_queries contextmanager"
+
+    _storage.db_name = WRITER_NAME
+    try:
+        yield
+    finally:
+        _storage.db_name = old_db_name
+
+
+class _ReadReplicaRouterStorage(threading.local):
+    def __init__(self):
+        super(_ReadReplicaRouterStorage, self).__init__()
+        self.db_name = None
+
+
+_storage = _ReadReplicaRouterStorage()
+
+
+class ReadReplicaRouter:
+    """
+    A database router that by default, reads from the writer database,
+    but can be overridden with a context manager to route all reads
+    to the read-replica.
+
+    See https://docs.djangoproject.com/en/2.2/topics/db/multi-db/#automatic-database-routing
+    """
+
+    def db_for_read(self, model, **hints):  # pylint: disable=unused-argument
+        """
+        Reads go the active reader name
+        """
+        return (
+            _storage.db_name if _storage.db_name in settings.DATABASES else WRITER_NAME
+        )
+
+    def db_for_write(self, model, **hints):  # pylint: disable=unused-argument
+        """
+        Writes always go to the writer.
+        """
+        return WRITER_NAME
+
+    def allow_relation(
+        self, obj1, obj2, **hints
+    ):  # pylint: disable=unused-argument, protected-access
+        """
+        Relations between objects are allowed if both objects are
+        in either the read-replica or the writer.
+        """
+        db_list = (READ_REPLICA_NAME, WRITER_NAME)
+        if obj1._state.db in db_list and obj2._state.db in db_list:
+            return True
+        return None
+
+    def allow_migrate(
+        self, db, app_label, model_name=None, **hints
+    ):  # pylint: disable=unused-argument
+        """
+        All non-auth models end up in this pool.
+        """
+        return True

--- a/edx_django_utils/db/tests/test_read_replica.py
+++ b/edx_django_utils/db/tests/test_read_replica.py
@@ -1,0 +1,104 @@
+"""
+Tests of edx_django_utils.db.read_replica.
+"""
+
+from importlib import reload
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+
+from .. import read_replica
+
+WRITER_ONLY_DATABASES = settings.DATABASES.copy()
+del WRITER_ONLY_DATABASES["read_replica"]
+
+READ_REPLICA_DATABASES = settings.DATABASES
+DATABASE_ROUTERS = settings.DATABASE_ROUTERS + [
+    "edx_django_utils.db.read_replica.ReadReplicaRouter"
+]
+
+
+class TestReadReplica(TestCase):
+    """
+    Tests of edx_django_utils.db.read_replica.
+    """
+
+    databases = ["default", "read_replica"]
+
+    def setUp(self):
+        super(TestReadReplica, self).setUp()
+        self.addCleanup(reload, read_replica)
+
+    def test_read_inside_write_error(self):
+        with self.assertRaises(AssertionError):
+            with read_replica.write_queries():
+                with read_replica.read_queries_only():
+                    pass  # pragma: no cover
+
+    def test_write_inside_read_error(self):
+        with self.assertRaises(AssertionError):
+            with read_replica.read_queries_only():
+                with read_replica.write_queries():
+                    pass  # pragma: no cover
+
+    def test_write_inside_write_ok(self):
+        with read_replica.write_queries():
+            with read_replica.write_queries():
+                pass
+
+    def test_read_inside_read_ok(self):
+        with read_replica.read_queries_only():
+            with read_replica.read_queries_only():
+                pass
+
+    def test_read_replica_name_from_default(self):
+        reload(read_replica)
+        assert read_replica.READ_REPLICA_NAME == "read_replica"
+
+    @override_settings(EDX_READ_REPLICA_DB_NAME="new_read_replica")
+    def test_read_replica_name_from_settings(self):
+        reload(read_replica)
+        assert read_replica.READ_REPLICA_NAME == "new_read_replica"
+
+    @override_settings(DATABASES=WRITER_ONLY_DATABASES)
+    def test_writer_name_from_default(self):
+        reload(read_replica)
+        assert read_replica.WRITER_NAME == "default"
+
+    @override_settings(EDX_WRITER_DB_NAME="new_default")
+    def test_writer_name_from_settings(self):
+        reload(read_replica)
+        assert read_replica.WRITER_NAME == "new_default"
+
+    @override_settings(DATABASES=WRITER_ONLY_DATABASES)
+    def test_read_replica_fallback(self):
+        reload(read_replica)
+        assert read_replica.READ_REPLICA_OR_DEFAULT == read_replica.WRITER_NAME
+
+    @override_settings(DATABASES=READ_REPLICA_DATABASES)
+    def test_read_replica_exists(self):
+        reload(read_replica)
+        assert read_replica.READ_REPLICA_OR_DEFAULT == read_replica.READ_REPLICA_NAME
+
+    @override_settings(
+        DATABASES=READ_REPLICA_DATABASES, DATABASE_ROUTERS=DATABASE_ROUTERS
+    )
+    def test_read_only_queries_from_database(self):
+        reload(read_replica)
+        User(username="test_user").save(using=read_replica.WRITER_NAME)
+
+        assert User.objects.all().count() == 1
+        with read_replica.read_queries_only():
+            assert User.objects.all().count() == 0
+
+    @override_settings(
+        DATABASES=READ_REPLICA_DATABASES, DATABASE_ROUTERS=DATABASE_ROUTERS
+    )
+    def test_router_writes(self):
+        reload(read_replica)
+        User(username="test_user").save()
+
+        assert User.objects.all().count() == 1
+        with read_replica.read_queries_only():
+            assert User.objects.all().count() == 0

--- a/edx_django_utils/tests/test_private_utils.py
+++ b/edx_django_utils/tests/test_private_utils.py
@@ -1,7 +1,6 @@
 """
 Tests for the private utils.
 """
-# pylint: disable=missing-docstring
 import unittest
 
 import django
@@ -14,7 +13,7 @@ class _TestMiddleware:
     pass
 
 
-class TestPrivateUtils(TestCase):
+class TestPrivateUtils(TestCase):  # pylint: disable=missing-class-docstring
 
     @override_settings(MIDDLEWARE=['required.Middleware'])
     def test_check_middleware_dependencies_simple_success(self):

--- a/test_settings.py
+++ b/test_settings.py
@@ -18,26 +18,32 @@ def root(*args):
 
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'default.db',
-        'USER': '',
-        'PASSWORD': '',
-        'HOST': '',
-        'PORT': '',
-    }
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "default.db",
+        "USER": "",
+        "PASSWORD": "",
+        "HOST": "",
+        "PORT": "",
+    },
+    "read_replica": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "read_replica.db",
+        "USER": "",
+        "PASSWORD": "",
+        "HOST": "",
+        "PORT": "",
+    },
 }
 
 INSTALLED_APPS = (
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'edx_django_utils',
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "edx_django_utils",
 )
 
-LOCALE_PATHS = [
-    root('edx_django_utils', 'conf', 'locale'),
-]
+LOCALE_PATHS = [root("edx_django_utils", "conf", "locale")]
 
-ROOT_URLCONF = 'edx_django_utils.urls'
+ROOT_URLCONF = "edx_django_utils.urls"
 
-SECRET_KEY = 'insecure-secret-key'
+SECRET_KEY = "insecure-secret-key"


### PR DESCRIPTION
This migrates the use_read_replica_if_available and read_replica_or_default
functions from edx_platform/common/djangoapps/utils/query.py, and augments
them with a pair of context managers for asserting that particular chunks
of code are read-only (and thus read-replica safe).

**Description:**

Describe in a couple of sentence what this PR adds

**JIRA:**

[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)

**Dependencies:**

List dependencies on other outstanding PRs, issues, etc.

**Merge deadline:**

List merge deadline (if any)

**Installation instructions:**

List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] @edx/arch-review (Required)
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
