### PR TITLE
ARCHBOM-1283: update CodeOwnerMetricMiddleware

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,11 +11,24 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
-
-[3.3.0] - 2020-07-017
-~~~~~~~~~~~~~~~~~~~~~
+[3.4.0] - 2020-07-20
+~~~~~~~~~~~~~~~~~~~~
 
 Added
+-----
+
+* Added get_current_transaction for monitoring that returns a transaction object with a name property.
+
+Updated
+-------
+
+* Updated CodeOwnerMetricMiddleware to use NewRelic's current transaction for cases where resolve() doesn't work to determine the code_owner, like for Middleware.
+
+[3.3.0] - 2020-07-16
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+-----
 
 * CodeOwnerMetricMiddleware was moved here (from edx-platform) in order to be able to take advantage of the ``code_owner`` metric in other IDAs. For details on this decision, see the `ADR for monitoring code owner`_. See the docstring for more details on usage.
 

--- a/edx_django_utils/monitoring/__init__.py
+++ b/edx_django_utils/monitoring/__init__.py
@@ -7,6 +7,7 @@ See README.rst for details.
 from .utils import (
     accumulate,
     function_trace,
+    get_current_transaction,
     increment,
     set_custom_metric,
     set_custom_metrics_for_course_key,

--- a/edx_django_utils/monitoring/code_owner/middleware.py
+++ b/edx_django_utils/monitoring/code_owner/middleware.py
@@ -37,6 +37,7 @@ class CodeOwnerMetricMiddleware:
 
     def process_exception(self, request, exception):
         self._set_code_owner_metric(request)
+        return None
 
     def _set_code_owner_metric(self, request):
         """

--- a/edx_django_utils/monitoring/code_owner/middleware.py
+++ b/edx_django_utils/monitoring/code_owner/middleware.py
@@ -40,7 +40,10 @@ class CodeOwnerMetricMiddleware:
 
     def _set_code_owner_metric(self, request):
         """
-        Sets the code_owner custom metric.
+        Sets the code_owner custom metric, as well as several supporting custom metrics.
+
+        See CodeOwnerMetricMiddleware docstring for a complete list of metrics.
+
         """
         code_owner, path_error = self._set_code_owner_metric_from_path(request)
         if code_owner:

--- a/edx_django_utils/monitoring/code_owner/middleware.py
+++ b/edx_django_utils/monitoring/code_owner/middleware.py
@@ -36,7 +36,7 @@ class CodeOwnerMetricMiddleware:
         return response
 
     def process_exception(self, request, exception):
-        pass
+        self._set_code_owner_metric(request)
 
     def _set_code_owner_metric(self, request):
         """
@@ -75,7 +75,7 @@ class CodeOwnerMetricMiddleware:
             (str, str): (code_owner, error_message), where at least one of these should be None
 
         """
-        if not is_code_owner_mappings_configured():
+        if not is_code_owner_mappings_configured():  # pragma: no cover
             return None, None
 
         try:

--- a/edx_django_utils/monitoring/code_owner/middleware.py
+++ b/edx_django_utils/monitoring/code_owner/middleware.py
@@ -37,7 +37,6 @@ class CodeOwnerMetricMiddleware:
 
     def process_exception(self, request, exception):
         self._set_code_owner_metric(request)
-        return None
 
     def _set_code_owner_metric(self, request):
         """

--- a/edx_django_utils/monitoring/code_owner/middleware.py
+++ b/edx_django_utils/monitoring/code_owner/middleware.py
@@ -3,9 +3,9 @@ Middleware for code_owner custom metric
 """
 import logging
 
-from django.urls import Resolver404, resolve
+from django.urls import resolve
 
-from edx_django_utils.monitoring import set_custom_metric
+from edx_django_utils.monitoring import get_current_transaction, set_custom_metric
 
 from .utils import get_code_owner_from_module, is_code_owner_mappings_configured
 
@@ -19,35 +19,96 @@ class CodeOwnerMetricMiddleware:
     Custom metrics set:
     - code_owner: The owning team mapped to the current view.
     - code_owner_mapping_error: If there are any errors when trying to perform the mapping.
-    - view_func_module: The __module__ of the view_func, which can be used to
-        find missing mappings.
+    - code_owner_path_error: The error mapping by path, if code_owner isn't found in other ways.
+    - code_owner_path_module: The __module__ of the view_func which was used to try to map to code_owner.
+        This can be used to find missing mappings.
+    - code_owner_transaction_error: The error mapping by transaction, if code_owner isn't found in other ways.
+    - code_owner_transaction_name: The current transaction name used to try to map to code_owner.
+        This can be used to find missing mappings.
 
     """
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
-        self._set_owner_metrics_for_request(request)
         response = self.get_response(request)
+        self._set_code_owner_metric(request)
         return response
 
-    def _set_owner_metrics_for_request(self, request):
+    def process_exception(self, request, exception):
+        pass
+
+    def _set_code_owner_metric(self, request):
+        """
+        Sets the code_owner custom metric.
+        """
+        code_owner, path_error = self._set_code_owner_metric_from_path(request)
+        if code_owner:
+            set_custom_metric('code_owner', code_owner)
+            return
+        if not path_error:
+            # module found, but mapping wasn't configured
+            return
+
+        code_owner, transaction_error = self._set_code_owner_metric_from_current_transaction(request)
+        if code_owner:
+            set_custom_metric('code_owner', code_owner)
+            return
+        if not transaction_error:
+            # transaction name found, but mapping wasn't configured
+            return
+
+        # only report errors if either code_owner couldn't be found
+        if path_error:
+            set_custom_metric('code_owner_path_error', path_error)
+        if transaction_error:
+            set_custom_metric('code_owner_transaction_error', transaction_error)
+
+    def _set_code_owner_metric_from_path(self, request):
         """
         Uses the request path to find the view_func and then sets code owner metrics based on the view.
+
+        Side-effects:
+            Sets code_owner_path_module custom metric, used to determine code_owner
+
+        Returns:
+            (str, str): (code_owner, error_message), where at least one of these should be None
+
         """
         if not is_code_owner_mappings_configured():
-            return
+            return None, None
 
         try:
             view_func, _, _ = resolve(request.path)
-            view_func_module = view_func.__module__
-            set_custom_metric('view_func_module', view_func_module)
-            code_owner = get_code_owner_from_module(view_func_module)
-            if code_owner:
-                set_custom_metric('code_owner', code_owner)
-        except Resolver404:
-            set_custom_metric(
-                'code_owner_mapping_error', "Couldn't resolve view for request path {}".format(request.path)
-            )
+            path_module = view_func.__module__
+            set_custom_metric('code_owner_path_module', path_module)
+            code_owner = get_code_owner_from_module(path_module)
+            return code_owner, None
         except Exception as e:  # pylint: disable=broad-except
-            set_custom_metric('code_owner_mapping_error', e)
+            return None, str(e)
+
+    def _set_code_owner_metric_from_current_transaction(self, request):
+        """
+        Uses the current transaction name to set the code owner metric.
+
+        Side-effects:
+            Sets code_owner_transaction_name custom metric, used to determine code_owner
+
+        Returns:
+            (str, str): (code_owner, error_message), where at least one of these should be None
+
+        """
+        if not is_code_owner_mappings_configured():
+            return None, None
+
+        try:
+            # Example: openedx.core.djangoapps.contentserver.middleware:StaticContentServer
+            transaction_name = get_current_transaction().name
+            if not transaction_name:
+                return None, 'No current transaction name found.'
+            set_custom_metric('code_owner_transaction_name', transaction_name)
+            module_name = transaction_name.split(':')[0]
+            code_owner = get_code_owner_from_module(module_name)
+            return code_owner, None
+        except Exception as e:  # pylint: disable=broad-except
+            return None, str(e)

--- a/edx_django_utils/monitoring/code_owner/tests/test_middleware.py
+++ b/edx_django_utils/monitoring/code_owner/tests/test_middleware.py
@@ -75,11 +75,10 @@ class CodeOwnerMetricMiddlewareTests(TestCase):
             )
 
             mock_set_custom_metric.reset_mock()
-            process_exception = self.middleware.process_exception(request, None)
+            self.middleware.process_exception(request, None)
             self._assert_code_owner_custom_metrics(
                 mock_set_custom_metric, expected_code_owner=expected_owner, path_module=expected_path_module
             )
-            self.assertIsNone(process_exception)
 
     @override_settings(
         CODE_OWNER_MAPPINGS={'team-red': ['edx_django_utils.monitoring.code_owner.tests.mock_views']},
@@ -107,11 +106,10 @@ class CodeOwnerMetricMiddlewareTests(TestCase):
             )
 
             mock_set_custom_metric.reset_mock()
-            process_exception = self.middleware.process_exception(request, None)
+            self.middleware.process_exception(request, None)
             self._assert_code_owner_custom_metrics(
                 mock_set_custom_metric, expected_code_owner=expected_owner, transaction_name=transaction_name
             )
-            self.assertIsNone(process_exception)
 
     @override_settings(
         CODE_OWNER_MAPPINGS={'team-red': ['edx_django_utils.monitoring.code_owner.tests.mock_views']},

--- a/edx_django_utils/monitoring/code_owner/tests/test_middleware.py
+++ b/edx_django_utils/monitoring/code_owner/tests/test_middleware.py
@@ -60,7 +60,7 @@ class CodeOwnerMetricMiddlewareTests(TestCase):
         ('/test/', 'team-red'),
     )
     @ddt.unpack
-    def test_code_owner_mapping_hits_and_misses(
+    def test_code_owner_path_mapping_hits_and_misses(
         self, request_path, expected_owner, mock_set_custom_metric
     ):
         with patch(
@@ -69,9 +69,34 @@ class CodeOwnerMetricMiddlewareTests(TestCase):
         ):
             request = RequestFactory().get(request_path)
             self.middleware(request)
-            expected_view_func_module = self._REQUEST_PATH_TO_MODULE_PATH[request_path]
+            expected_path_module = self._REQUEST_PATH_TO_MODULE_PATH[request_path]
             self._assert_code_owner_custom_metrics(
-                expected_view_func_module, mock_set_custom_metric, expected_code_owner=expected_owner
+                mock_set_custom_metric, expected_code_owner=expected_owner, path_module=expected_path_module
+            )
+
+    @override_settings(
+        CODE_OWNER_MAPPINGS={'team-red': ['edx_django_utils.monitoring.code_owner.tests.mock_views']},
+        ROOT_URLCONF=__name__,
+    )
+    @patch('edx_django_utils.monitoring.code_owner.middleware.set_custom_metric')
+    @patch('newrelic.agent')
+    @ddt.data(
+        ('edx_django_utils.monitoring.code_owner.tests.test_middleware:MockMiddlewareViewTest', None),
+        ('edx_django_utils.monitoring.code_owner.tests.mock_views:MockViewTest', 'team-red'),
+    )
+    @ddt.unpack
+    def test_code_owner_transaction_mapping_hits_and_misses(
+        self, transaction_name, expected_owner, mock_newrelic_agent, mock_set_custom_metric
+    ):
+        mock_newrelic_agent.current_transaction().name = transaction_name
+        with patch(
+                'edx_django_utils.monitoring.code_owner.utils._PATH_TO_CODE_OWNER_MAPPINGS',
+                _process_code_owner_mappings()
+        ):
+            request = RequestFactory().get('/bad/path/')
+            self.middleware(request)
+            self._assert_code_owner_custom_metrics(
+                mock_set_custom_metric, expected_code_owner=expected_owner, transaction_name=transaction_name
             )
 
     @patch('edx_django_utils.monitoring.code_owner.middleware.set_custom_metric')
@@ -84,7 +109,7 @@ class CodeOwnerMetricMiddlewareTests(TestCase):
         CODE_OWNER_MAPPINGS={'team-red': ['lms.djangoapps.monitoring.tests.mock_views']},
     )
     @patch('edx_django_utils.monitoring.code_owner.middleware.set_custom_metric')
-    def test_no_resolver_for_request_path(self, mock_set_custom_metric):
+    def test_no_resolver_for_path_and_no_transaction(self, mock_set_custom_metric):
         with patch(
                 'edx_django_utils.monitoring.code_owner.utils._PATH_TO_CODE_OWNER_MAPPINGS',
                 _process_code_owner_mappings()
@@ -92,7 +117,7 @@ class CodeOwnerMetricMiddlewareTests(TestCase):
             request = RequestFactory().get('/bad/path/')
             self.middleware(request)
             self._assert_code_owner_custom_metrics(
-                None, mock_set_custom_metric, has_error=True
+                mock_set_custom_metric, has_path_error=True, has_transaction_error=True
             )
 
     @override_settings(
@@ -107,23 +132,28 @@ class CodeOwnerMetricMiddlewareTests(TestCase):
         ):
             request = RequestFactory().get('/test/')
             self.middleware(request)
-            expected_view_func_module = self._REQUEST_PATH_TO_MODULE_PATH['/test/']
+            expected_path_module = self._REQUEST_PATH_TO_MODULE_PATH['/test/']
             self._assert_code_owner_custom_metrics(
-                expected_view_func_module, mock_set_custom_metric, has_error=True
+                mock_set_custom_metric, path_module=expected_path_module,
+                has_path_error=True, has_transaction_error=True
             )
 
-    def _assert_code_owner_custom_metrics(
-        self, view_func_module, mock_set_custom_metric, expected_code_owner=None, has_error=False,
-    ):
+    def _assert_code_owner_custom_metrics(self, mock_set_custom_metric, expected_code_owner=None,
+                                          path_module=None, has_path_error=False,
+                                          transaction_name=None, has_transaction_error=False):
         """ Performs a set of assertions around having set the proper custom metrics. """
         call_list = []
-        if view_func_module:
-            call_list.append(call('view_func_module', view_func_module))
         if expected_code_owner:
             call_list.append(call('code_owner', expected_code_owner))
-        if has_error:
-            call_list.append(call('code_owner_mapping_error', ANY))
-        mock_set_custom_metric.assert_has_calls(call_list)
+        if path_module:
+            call_list.append(call('code_owner_path_module', path_module))
+        if has_path_error:
+            call_list.append(call('code_owner_path_error', ANY))
+        if transaction_name:
+            call_list.append(call('code_owner_transaction_name', transaction_name))
+        if has_transaction_error:
+            call_list.append(call('code_owner_transaction_error', ANY))
+        mock_set_custom_metric.assert_has_calls(call_list, any_order=True)
         self.assertEqual(
             len(mock_set_custom_metric.call_args_list), len(call_list),
             'Expected calls {} vs actual calls {}'.format(call_list, mock_set_custom_metric.call_args_list)

--- a/edx_django_utils/monitoring/tests/test_monitoring.py
+++ b/edx_django_utils/monitoring/tests/test_monitoring.py
@@ -73,3 +73,13 @@ class TestMonitoringCustomMetrics(TestCase):
     def test_memory_middleware_dependencies_failure(self):
         with self.assertRaises(AssertionError):
             MonitoringMemoryMiddleware()
+
+    @patch('newrelic.agent')
+    def test_get_current_transaction(self, mock_newrelic_agent):
+        mock_newrelic_agent.current_transaction().name = 'fake-transaction'
+        current_transaction = monitoring.get_current_transaction()
+        self.assertEqual(current_transaction.name, 'fake-transaction')
+
+    def test_get_current_transaction_without_newrelic(self):
+        current_transaction = monitoring.get_current_transaction()
+        self.assertEqual(current_transaction.name, None)

--- a/edx_django_utils/monitoring/utils.py
+++ b/edx_django_utils/monitoring/utils.py
@@ -114,3 +114,35 @@ def function_trace(function_name):
                 yield
     else:
         yield
+
+
+class MonitoringTransaction():
+    """
+    Represents a monitoring transaction (likely the current transaction).
+    """
+    def __init__(self, transaction):
+        self.transaction = transaction
+
+    @property
+    def name(self):
+        """
+        The name of the transaction.
+
+        For NewRelic, the name may look like:
+            openedx.core.djangoapps.contentserver.middleware:StaticContentServer
+
+        """
+        if self.transaction and hasattr(self.transaction, 'name'):
+            return self.transaction.name
+        return None
+
+
+def get_current_transaction():
+    """
+    Returns the current transaction.
+    """
+    current_transaction = None
+    if newrelic:
+        current_transaction = newrelic.agent.current_transaction()
+
+    return MonitoringTransaction(current_transaction)


### PR DESCRIPTION
**Description:**

- add get_current_transaction function which returns am
object with a name property.
- update CodeOwnerMetricMiddleware to use the current
transaction to determine the code_owner metric in cases
where resolve doesn't work.

**JIRA:**

[ARCHBOM-1283](https://openedx.atlassian.net/browse/ARCHBOM-1283)

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.

