### PR TITLE
ARCHBOM-1357: add catch-all to CodeOwnerMetricMiddleware

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,13 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[3.5.0] - 2020-07-22
+
+Updated
+-------
+
+* Added a catch-all capability to CodeOwnerMetricMiddleware when CODE_OWNER_MAPPINGS includes a '*' as a team's module. The catch-all is used only if there is no other match.
+
 [3.4.0] - 2020-07-20
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/code_owner/utils.py
+++ b/edx_django_utils/monitoring/code_owner/utils.py
@@ -18,6 +18,18 @@ def get_code_owner_from_module(module):
     this lookup would match on 'openedx.features.discounts' before
     'openedx.features', because the former is more specific.
 
+    Uses CODE_OWNER_MAPPINGS Django Setting.  An example::
+
+        CODE_OWNER_MAPPINGS = {
+            'team-red': [
+                'xblock_django',
+                'openedx.core.djangoapps.xblock',
+            ],
+            'team-blue': [
+                'badges',
+            ],
+        }
+
     """
     assert _PATH_TO_CODE_OWNER_MAPPINGS != _INVALID_CODE_OWNER_MAPPING,\
         'CODE_OWNER_MAPPINGS django setting set with invalid configuration. See logs for details.'
@@ -48,18 +60,6 @@ def _process_code_owner_mappings():
          (dict): optimized dict for success processing, None if there are no
             configured mappings, or _INVALID_CODE_OWNER_MAPPING if there is an
             error processing the setting.
-
-    Example CODE_OWNER_MAPPINGS Django Setting::
-
-        CODE_OWNER_MAPPINGS = {
-            'team-red': [
-                'xblock_django',
-                'openedx.core.djangoapps.xblock',
-            ],
-            'team-blue': [
-                'badges',
-            ],
-        }
 
     Example return value::
 
@@ -109,8 +109,8 @@ def _process_code_owner_mappings():
 # TODO: Update annotations.  This is more of a non-toggle setting than a toggle setting.
 _CODE_OWNER_MAPPINGS = None
 
-# TODO: ARCHBOM-1283: Either remove this if it is no longer needed when using the NewRelic transaction name, or
-# add a new Django Setting named CODE_OWNER_OPTIONAL_MODULE_PREFIXES that takes a list of prefixes.
+# TODO: Remove this LMS spcific configuration by replacing with a Django Setting named
+#    CODE_OWNER_OPTIONAL_MODULE_PREFIXES that takes a list of module prefixes (without the final period).
 _OPTIONAL_MODULE_PREFIX_PATTERN = re.compile(r'^(lms|common|openedx\.core)\.djangoapps\.')
 _INVALID_CODE_OWNER_MAPPING = 'invalid-code-owner-mapping'
 # lookup table for code owner given a module path


### PR DESCRIPTION
**Description:**

Added a catch-all capability to CodeOwnerMetricMiddleware
when CODE_OWNER_MAPPINGS includes a '*' as a team's
module. The catch-all is used only if there is no other
match.

**JIRA:**

[ARCHBOM-1357](https://openedx.atlassian.net/browse/ARCHBOM-1357)

**Reviewers:**
- [x] @edx/arch-review (Required)

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [X] Version bumped
- [X] Changelog record added
- [X] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)