### PR TITLE
Add ignore transaction util

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,6 @@ instructions.
 4. If D happened instead - check failed.
 
 **Reviewers:**
-- [ ] @edx/arch-review (Required)
 - [ ] tag reviewer
 
 **Merge checklist:**
@@ -37,16 +36,15 @@ instructions.
 - [ ] Changelog record added
 - [ ] Documentation updated (not only docstrings)
 - [ ] Commits are squashed
-- [ ] PR author is listed in AUTHORS
 
 **Post merge:**
 - [ ] Create a tag
-- [ ] Check new version is pushed to PyPi after tag-triggered build is 
+- [ ] Check new version is pushed to PyPi after tag-triggered build is
       finished.
 - [ ] Delete working branch (if not needed anymore)
 
 **Author concerns:**
 
 List any concerns about this PR - inelegant
-solutions, hacks, quick-and-dirty implementations, concerns about 
+solutions, hacks, quick-and-dirty implementations, concerns about
 migrations, etc.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,10 +15,20 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+
+[3.6.0] - 2020-08-04
+~~~~~~~~~~~~~~~~~~~~
+
 Added
 _____
 
 * Improved documentation for CodeOwnerMetricMiddleware, including a how_tos/add_code_owner_custom_metric_to_an_ida.rst for adding it to a new IDA.
+* Added ignore_transaction monitoring utility to ignore transactions we don't want tracked.
+
+Updated
+_______
+
+* Moved transaction-related monitoring code into it's own file. Still exposed through `__init__.py` so it's a non-breaking change.
 
 [3.5.0] - 2020-07-22
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "3.5.0"
+__version__ = "3.6.0"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/__init__.py
+++ b/edx_django_utils/monitoring/__init__.py
@@ -3,13 +3,5 @@ Metrics utilities public api
 
 See README.rst for details.
 """
-
-from .utils import (
-    accumulate,
-    function_trace,
-    get_current_transaction,
-    increment,
-    set_custom_metric,
-    set_custom_metrics_for_course_key,
-    set_monitoring_transaction_name
-)
+from .transactions import function_trace, get_current_transaction, ignore_transaction, set_monitoring_transaction_name
+from .utils import accumulate, increment, set_custom_metric, set_custom_metrics_for_course_key

--- a/edx_django_utils/monitoring/transactions.py
+++ b/edx_django_utils/monitoring/transactions.py
@@ -1,0 +1,95 @@
+"""
+This is a collection of transaction-related monitoring utilities.
+
+Usage:
+
+    from edx_django_utils.monitoring import ignore_transaction
+    ...
+    # called from inside a view you want ignored
+    ignore_transaction()
+
+Please remember to expose any new methods in the `__init__.py` file.
+"""
+
+from contextlib import contextmanager
+
+try:
+    import newrelic.agent
+except ImportError:
+    newrelic = None  # pylint: disable=invalid-name
+
+
+def set_monitoring_transaction_name(name, group=None, priority=None):
+    """
+    Sets the transaction name for monitoring.
+
+    This is not cached, and only support reporting to New Relic.
+
+    """
+    if newrelic:  # pragma: no cover
+        newrelic.agent.set_transaction_name(name, group, priority)
+
+
+def ignore_transaction():
+    """
+    Ignore the transaction in monitoring
+
+    This allows us to ignore code paths that are unhelpful to include, such as
+    `/health/` checks.
+    """
+    if newrelic:  # pragma: no cover
+        newrelic.agent.ignore_transaction()
+
+
+@contextmanager
+def function_trace(function_name):
+    """
+    Wraps a chunk of code that we want to appear as a separate, explicit,
+    segment in our monitoring tools.
+    """
+    # Not covering this because if we mock it, we're not really testing anything
+    # anyway. If something did break, it should show up in tests for apps that
+    # use this code with newrelic enabled, on whatever version of newrelic they
+    # run.
+    if newrelic:  # pragma: no cover
+        if newrelic.version_info[0] >= 5:
+            with newrelic.agent.FunctionTrace(function_name):
+                yield
+        else:
+            nr_transaction = newrelic.agent.current_transaction()
+            with newrelic.agent.FunctionTrace(nr_transaction, function_name):
+                yield
+    else:
+        yield
+
+
+class MonitoringTransaction():
+    """
+    Represents a monitoring transaction (likely the current transaction).
+    """
+    def __init__(self, transaction):
+        self.transaction = transaction
+
+    @property
+    def name(self):
+        """
+        The name of the transaction.
+
+        For NewRelic, the name may look like:
+            openedx.core.djangoapps.contentserver.middleware:StaticContentServer
+
+        """
+        if self.transaction and hasattr(self.transaction, 'name'):
+            return self.transaction.name
+        return None
+
+
+def get_current_transaction():
+    """
+    Returns the current transaction.
+    """
+    current_transaction = None
+    if newrelic:
+        current_transaction = newrelic.agent.current_transaction()
+
+    return MonitoringTransaction(current_transaction)

--- a/edx_django_utils/monitoring/utils.py
+++ b/edx_django_utils/monitoring/utils.py
@@ -17,9 +17,8 @@ https://openedx.atlassian.net/wiki/display/PERF/Custom+Metrics+in+New+Relic
 
 At this time, these custom metrics will only be reported to New Relic.
 
+Please remember to expose any new methods in the `__init__.py` file.
 """
-from contextlib import contextmanager
-
 from . import middleware
 
 try:
@@ -81,68 +80,3 @@ def set_custom_metric(key, value):
     """
     if newrelic:  # pragma: no cover
         newrelic.agent.add_custom_parameter(key, value)
-
-
-def set_monitoring_transaction_name(name, group=None, priority=None):
-    """
-    Sets the transaction name for monitoring.
-
-    This is not cached, and only support reporting to New Relic.
-
-    """
-    if newrelic:  # pragma: no cover
-        newrelic.agent.set_transaction_name(name, group, priority)
-
-
-@contextmanager
-def function_trace(function_name):
-    """
-    Wraps a chunk of code that we want to appear as a separate, explicit,
-    segment in our monitoring tools.
-    """
-    # Not covering this because if we mock it, we're not really testing anything
-    # anyway. If something did break, it should show up in tests for apps that
-    # use this code with newrelic enabled, on whatever version of newrelic they
-    # run.
-    if newrelic:  # pragma: no cover
-        if newrelic.version_info[0] >= 5:
-            with newrelic.agent.FunctionTrace(function_name):
-                yield
-        else:
-            nr_transaction = newrelic.agent.current_transaction()
-            with newrelic.agent.FunctionTrace(nr_transaction, function_name):
-                yield
-    else:
-        yield
-
-
-class MonitoringTransaction():
-    """
-    Represents a monitoring transaction (likely the current transaction).
-    """
-    def __init__(self, transaction):
-        self.transaction = transaction
-
-    @property
-    def name(self):
-        """
-        The name of the transaction.
-
-        For NewRelic, the name may look like:
-            openedx.core.djangoapps.contentserver.middleware:StaticContentServer
-
-        """
-        if self.transaction and hasattr(self.transaction, 'name'):
-            return self.transaction.name
-        return None
-
-
-def get_current_transaction():
-    """
-    Returns the current transaction.
-    """
-    current_transaction = None
-    if newrelic:
-        current_transaction = newrelic.agent.current_transaction()
-
-    return MonitoringTransaction(current_transaction)


### PR DESCRIPTION
**Description:**

Adds an `ignore_transaction` utility method. This will allows consuming apps to ignore transaction in views we don't want monitored (like `/health/` checks)

**JIRA:**

No JIRA ticket.

**Dependencies:**

N/A

**Merge deadline:**

N/A

**Installation instructions:**

N/A

**Testing instructions:**

N/A

**Reviewers:**
- [ ] @edx/arch-review (Required)
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
