### PR TITLE
 Adding plugin api in __init__.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Unreleased
 ~~~~~~~~~~
 
 
+[3.7.1] - 2020-08-10
+~~~~~~~~~~~~~~~~~~~~
+
+* Exposing all public functions in edx_django_utils/plugins directory in its __init__.py file.
+    - this was done to keep inline with standard/pattern used in other packages in edx_django_utils
+
 [3.7.0] - 2020-08-10
 ~~~~~~~~~~~~~~~~~~~~
 * Adding Plugin infrastructure

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,11 @@ The full documentation is in the docs directory.
 
 TODO: Publish to https://edx-django-utils.readthedocs.org.
 
+Design Pattern followed by packages
+-----------------------------------
+
+All tools in edx_django_utils should expose their public api in their __init__.py files. This entails adding to __init__.py all functions/classes/constants/objects that are intended to be used by users of library.
+
 License
 -------
 

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "3.7.0"
+__version__ = "3.7.1"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/plugins/__init__.py
+++ b/edx_django_utils/plugins/__init__.py
@@ -1,0 +1,14 @@
+"""
+Plugins infrastructure
+
+See README.rst for details.
+"""
+
+from .constants import PluginSettings, PluginURLs
+from .plugin_apps import get_apps
+from .plugin_contexts import get_plugins_view_context
+from .plugin_manager import PluginManager
+from .plugin_settings import add_plugins
+from .plugin_signals import connect_receivers
+from .plugin_urls import get_patterns
+from .registry import get_app_configs

--- a/edx_django_utils/plugins/plugin_apps.py
+++ b/edx_django_utils/plugins/plugin_apps.py
@@ -1,5 +1,7 @@
 """
 Methods to get plugin apps
+
+Please remember to expose any new public methods in the `__init__.py` file.
 """
 from logging import getLogger
 

--- a/edx_django_utils/plugins/plugin_contexts.py
+++ b/edx_django_utils/plugins/plugin_contexts.py
@@ -1,5 +1,7 @@
 """
 Various functions to get view contexts
+
+Please remember to expose any new public methods in the `__init__.py` file.
 """
 import functools
 from importlib import import_module

--- a/edx_django_utils/plugins/plugin_manager.py
+++ b/edx_django_utils/plugins/plugin_manager.py
@@ -1,5 +1,7 @@
 """
 Adds support for first class plugins that can be added to an IDA.
+
+Please remember to expose any new public methods in the `__init__.py` file.
 """
 
 import functools

--- a/edx_django_utils/plugins/plugin_settings.py
+++ b/edx_django_utils/plugins/plugin_settings.py
@@ -1,5 +1,7 @@
 """
 Functions that deal with settings related to plugins
+
+Please remember to expose any new public methods in the `__init__.py` file.
 """
 from logging import getLogger
 

--- a/edx_django_utils/plugins/plugin_signals.py
+++ b/edx_django_utils/plugins/plugin_signals.py
@@ -1,5 +1,7 @@
 """
 Allows plugins to work with django signals
+
+Please remember to expose any new public methods in the `__init__.py` file.
 """
 from logging import getLogger
 

--- a/edx_django_utils/plugins/plugin_urls.py
+++ b/edx_django_utils/plugins/plugin_urls.py
@@ -1,5 +1,7 @@
 """
 Urls utility functions
+
+Please remember to expose any new public methods in the `__init__.py` file.
 """
 from logging import getLogger
 

--- a/edx_django_utils/plugins/registry.py
+++ b/edx_django_utils/plugins/registry.py
@@ -1,5 +1,7 @@
 """
 Code to create Registry of django app plugins
+
+Please remember to expose any new public methods in the `__init__.py` file.
 """
 import six
 

--- a/edx_django_utils/plugins/utils.py
+++ b/edx_django_utils/plugins/utils.py
@@ -1,5 +1,7 @@
 """
 utils to help with imports
+
+Please remember to expose any new public methods in the `__init__.py` file.
 """
 from importlib import import_module as system_import_module
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,3 +14,6 @@ Django<2.3 # to stay on LTS version
 mock<4.0   # requires python>3.5
 zipp<2.0   # newer versions require python>3.5
 
+# stevedore 2.0.0 requires python >= 3.6
+stevedore<2.0.0
+


### PR DESCRIPTION
This PR exposes all public functions in edx_django_utils/plugins directory in its __init__.py file.
    - this was done to keep inline with standard/pattern used in other packages in edx_django_utils


**JIRA:**

[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)

**Dependencies:**

List dependencies on other outstanding PRs, issues, etc.

**Merge deadline:**

List merge deadline (if any)

**Installation instructions:**

List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
