### PR TITLE
BOM 1970: Unpin psutils from edx-django-utils

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.7.2] - 2020-08-11
+~~~~~~~~~~~~~~~~~~~~
+
+* Upgrade psutil to latest version
 
 [3.7.1] - 2020-08-10
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "3.7.1"
+__version__ = "3.7.2"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/middleware.py
+++ b/edx_django_utils/monitoring/middleware.py
@@ -158,10 +158,10 @@ class MonitoringMemoryMiddleware(MiddlewareMixin):
 
         process = psutil.Process()
         process_data = {
-            'memory_info': process.get_memory_info(),
-            'ext_memory_info': process.get_ext_memory_info(),
-            'memory_percent': process.get_memory_percent(),
-            'cpu_percent': process.get_cpu_percent(),
+            'memory_info': process.memory_info(),
+            'ext_memory_info': process.memory_info_ex(),
+            'memory_percent': process.memory_percent(),
+            'cpu_percent': process.cpu_percent(),
         }
 
         log.info(u"%s Machine memory usage: %s; Process memory usage: %s", log_prefix, machine_data, process_data)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,6 +5,6 @@
 Django                    # Web application framework
 django-waffle             # Allows for feature toggles in Django.
 newrelic                  # New Relic agent for performance monitoring
-psutil==1.2.1             # Library for retrieving information on running processes and system utilization
+psutil                    # Library for retrieving information on running processes and system utilization
                           # NOTE: psutil pinned to match edx-platform version. Will need to be updated at the same time.
 stevedore                 # Used by plugins to make importing easier

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,10 +6,10 @@
 #
 django-waffle==1.0.0      # via -r requirements/base.in
 django==2.2.15            # via -c requirements/constraints.txt, -r requirements/base.in
-newrelic==5.14.1.144      # via -r requirements/base.in
+newrelic==5.16.0.145      # via -r requirements/base.in
 pbr==5.4.5                # via stevedore
-psutil==1.2.1             # via -r requirements/base.in
+psutil==5.7.2             # via -r requirements/base.in
 pytz==2020.1              # via django
 six==1.15.0               # via stevedore
 sqlparse==0.3.1           # via django
-stevedore==1.32.0         # via -r requirements/base.in
+stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -34,7 +34,7 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt
 more-itertools==8.4.0     # via -r requirements/quality.txt, pytest
-newrelic==5.14.1.144      # via -r requirements/quality.txt
+newrelic==5.16.0.145      # via -r requirements/quality.txt
 packaging==20.4           # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 path.py==12.5.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
@@ -43,7 +43,7 @@ pbr==5.4.5                # via -r requirements/quality.txt, stevedore
 pip-tools==5.3.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
-psutil==1.2.1             # via -r requirements/quality.txt
+psutil==5.7.2             # via -r requirements/quality.txt
 py==1.9.0                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
 pydocstyle==5.0.2         # via -r requirements/quality.txt
@@ -62,10 +62,10 @@ requests==2.24.0          # via -r requirements/travis.txt, codecov
 six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, diff-cover, edx-i18n-tools, edx-lint, mock, packaging, pathlib2, pip-tools, stevedore, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 sqlparse==0.3.1           # via -r requirements/quality.txt, django
-stevedore==1.32.0         # via -r requirements/quality.txt
+stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/quality.txt
 toml==0.10.1              # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
-tox==3.18.1               # via -r requirements/travis.txt, tox-battery
+tox==3.19.0               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 urllib3==1.25.10          # via -r requirements/travis.txt, requests
 virtualenv==20.0.30       # via -r requirements/travis.txt, tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -25,13 +25,13 @@ jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
-newrelic==5.14.1.144      # via -r requirements/test.txt
+newrelic==5.16.0.145      # via -r requirements/test.txt
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/test.txt, stevedore
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-psutil==1.2.1             # via -r requirements/test.txt
+psutil==5.7.2             # via -r requirements/test.txt
 py==1.9.0                 # via -r requirements/test.txt, pytest
 pygments==2.6.1           # via doc8, readme-renderer, sphinx
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
@@ -45,7 +45,7 @@ requests==2.24.0          # via requests-toolbelt, sphinx, twine
 restructuredtext-lint==1.3.1  # via doc8
 six==1.15.0               # via -r requirements/test.txt, bleach, doc8, edx-sphinx-theme, mock, packaging, pathlib2, readme-renderer, stevedore
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.1.2             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.2.0             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -53,7 +53,7 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.3.1           # via -r requirements/test.txt, django
-stevedore==1.32.0         # via -r requirements/test.txt, doc8
+stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/test.txt, doc8
 toml==0.10.1              # via -r requirements/test.txt, pytest
 tqdm==4.48.2              # via twine
 twine==1.15.0             # via -r requirements/doc.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -20,12 +20,12 @@ lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
-newrelic==5.14.1.144      # via -r requirements/test.txt
+newrelic==5.16.0.145      # via -r requirements/test.txt
 packaging==20.4           # via -r requirements/test.txt, pytest
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-psutil==1.2.1             # via -r requirements/test.txt
+psutil==5.7.2             # via -r requirements/test.txt
 py==1.9.0                 # via -r requirements/test.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pydocstyle==5.0.2         # via -r requirements/quality.in
@@ -41,7 +41,7 @@ pytz==2020.1              # via -r requirements/test.txt, django
 six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, mock, packaging, pathlib2, stevedore
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via -r requirements/test.txt, django
-stevedore==1.32.0         # via -r requirements/test.txt
+stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/test.txt
 toml==0.10.1              # via -r requirements/test.txt, pytest
 typed-ast==1.4.1          # via astroid
 wrapt==1.11.2             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,12 +12,12 @@ importlib-metadata==1.7.0  # via pluggy, pytest
 iniconfig==1.0.1          # via pytest
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
 more-itertools==8.4.0     # via pytest
-newrelic==5.14.1.144      # via -r requirements/base.txt
+newrelic==5.16.0.145      # via -r requirements/base.txt
 packaging==20.4           # via pytest
 pathlib2==2.3.5           # via pytest
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
 pluggy==0.13.1            # via pytest
-psutil==1.2.1             # via -r requirements/base.txt
+psutil==5.7.2             # via -r requirements/base.txt
 py==1.9.0                 # via pytest
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.0        # via -r requirements/test.in
@@ -26,6 +26,6 @@ pytest==6.0.1             # via pytest-cov, pytest-django
 pytz==2020.1              # via -r requirements/base.txt, django
 six==1.15.0               # via -r requirements/base.txt, mock, packaging, pathlib2, stevedore
 sqlparse==0.3.1           # via -r requirements/base.txt, django
-stevedore==1.32.0         # via -r requirements/base.txt
+stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/base.txt
 toml==0.10.1              # via pytest
 zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -23,7 +23,7 @@ requests==2.24.0          # via codecov
 six==1.15.0               # via mock, packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
-tox==3.18.1               # via -r requirements/travis.in, tox-battery
+tox==3.19.0               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.10          # via requests
 virtualenv==20.0.30       # via tox
 zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
Relevant JIRA : https://openedx.atlassian.net/browse/BOM-1970
First we need to merge this and then we can un-pin in edx-platform.