### PR TITLE
ARCHBOM-1260: enable code_owner for celery tasks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,21 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.12.0] - 2020-11-17
+~~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* Added set_code_owner_attribute decorator for use with celery tasks.
+* Added set_code_owner_attribute_from_module as an alternative to the decorator.
+
+Updated
+_______
+
+* Cleaned up some of the code owner middleware code. In doing so, renamed custom attribute code_owner_path_module to code_owner_module. This may affect monitoring dashboards. Also slightly changed when error custom attributes are set.
+
+
 [3.11.0] - 2020-10-31
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "3.11.0"
+__version__ = "3.12.0"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/__init__.py
+++ b/edx_django_utils/monitoring/__init__.py
@@ -4,7 +4,11 @@ Metrics utilities public api
 See README.rst for details.
 """
 from .internal.code_owner.middleware import CodeOwnerMonitoringMiddleware
-from .internal.code_owner.utils import get_code_owner_from_module
+from .internal.code_owner.utils import (
+    get_code_owner_from_module,
+    set_code_owner_attribute,
+    set_code_owner_attribute_from_module
+)
 from .internal.middleware import CachedCustomMonitoringMiddleware, MonitoringMemoryMiddleware
 from .internal.transactions import (
     function_trace,

--- a/edx_django_utils/monitoring/docs/how_tos/add_code_owner_custom_attribute_to_an_ida.rst
+++ b/edx_django_utils/monitoring/docs/how_tos/add_code_owner_custom_attribute_to_an_ida.rst
@@ -21,6 +21,25 @@ Setting up the Middleware
 
 You simply need to add ``edx_django_utils.monitoring.CodeOwnerMonitoringMiddleware`` as described in the README to make this functionality available. Then it is ready to be configured.
 
+Handling celery tasks
+---------------------
+
+Celery tasks require use of a special decorator to set the ``code_owner`` custom attribute because no middleware will be run.
+
+Here is an example::
+
+  @task()
+  @set_code_owner_attribute
+  def example_task():
+      ...
+
+If the task is not compatible with additional decorators, you can use the following alternative::
+
+  @task()
+  def example_task():
+      set_code_owner_attribute_from_module(__name__)
+      ...
+
 Configuring your app settings
 -----------------------------
 


### PR DESCRIPTION
**Description:**

* add set_code_owner_attribute decorator for use with celery tasks.
* clean up code owner middleware code.
* rename custom attribute code_owner_path_module to
code_owner_module. This may affect monitoring dashboards.
* minor change in when error custom attributes are set.

**JIRA:**

[ARCHBOM-1260](https://openedx.atlassian.net/browse/ARCHBOM-1260)

**Testing:**

WIP testing in edx-platform https://github.com/edx/edx-platform/pull/25584 (currently failing)

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)