### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[3.11.1] - 2020-11-31
+~~~~~~~~~~~~~~~~~~~~~
+*  Updated README.rst and made build status badge point to travis-ci.com instead of travis-ci.org
 
 [3.11.0] - 2020-10-31
 ~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -82,8 +82,8 @@ refer to this `list of resources`_ if you need any assistance.
     :target: https://pypi.python.org/pypi/edx-django-utils/
     :alt: PyPI
 
-.. |travis-badge| image:: https://travis-ci.org/edx/edx-django-utils.svg?branch=master
-    :target: https://travis-ci.org/edx/edx-django-utils
+.. |travis-badge| image:: https://travis-ci.com/edx/edx-django-utils.svg?branch=master
+    :target: https://travis-ci.com/edx/edx-django-utils
     :alt: Travis
 
 .. |codecov-badge| image:: http://codecov.io/github/edx/edx-django-utils/coverage.svg?branch=master

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "3.11.0"
+__version__ = "3.11.1"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089 