### PR TITLE
 ARCHBOM-1636: add note about task_prerun

### DIFF
--- a/edx_django_utils/monitoring/docs/how_tos/add_code_owner_custom_attribute_to_an_ida.rst
+++ b/edx_django_utils/monitoring/docs/how_tos/add_code_owner_custom_attribute_to_an_ida.rst
@@ -40,6 +40,10 @@ If the task is not compatible with additional decorators, you can use the follow
       set_code_owner_attribute_from_module(__name__)
       ...
 
+An untested potential alternative to the ``@set_code_owner_attribute`` decorator is to try celery's `task_prerun signal`_ in an IDA, which would also ensure all future celery tasks are automatically handled.
+
+.. _task_prerun signal: https://docs.celeryproject.org/en/stable/userguide/signals.html#task-prerun
+
 Configuring your app settings
 -----------------------------
 


### PR DESCRIPTION
**Description:**

The celery signal task_prerun is a potential
alternative for the decorator. This is being
noted for our future selves, which will also
help clarify that it wasn't yet tried.

**JIRA:**

[ARCHBOM-1636](https://openedx.atlassian.net/browse/ARCHBOM-1636)

**Merge checklist:**
- [X] All reviewers approved
- [X] CI build is green
- [X] ~Version bumped~
- [X] ~Changelog record added~
- [X] Documentation updated (not only docstrings)
- [X] Commits are squashed

**Post merge:**
- [X] ~Create a tag~
- [X] ~Check new version is pushed to PyPi after tag-triggered build is
      finished.~
- [X] Delete working branch (if not needed anymore)
