### PR TITLE
SE-3724: squash warnings

### DIFF
--- a/edx_django_utils/monitoring/internal/middleware.py
+++ b/edx_django_utils/monitoring/internal/middleware.py
@@ -177,7 +177,7 @@ class MonitoringMemoryMiddleware(MiddlewareMixin):
         process = psutil.Process()
         process_data = {
             'memory_info': process.memory_info(),
-            'ext_memory_info': process.memory_info_ex(),
+            'ext_memory_info': process.memory_info(),
             'memory_percent': process.memory_percent(),
             'cpu_percent': process.cpu_percent(),
         }


### PR DESCRIPTION
**Description:**

This PR squashes the following warning (as part of the [Squash a Warning event](https://discuss.openedx.org/t/squash-a-warning-earn-a-badge/3497)):

> edx_django_utils/monitoring/tests/test_middleware.py::TestMonitoringMemoryMiddleware::test_memory_monitoring_when_enabled
>   /home/elrull/workspace/opencraft/edx-django-utils/edx_django_utils/monitoring/internal/middleware.py:180: DeprecationWarning: memory_info_ex() is deprecated and will be removed; use memory_info() instead
>     'ext_memory_info': process.memory_info_ex(),

It can be checked running tests:

    make test

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [ ] ~Version bumped~
- [ ] ~Changelog record added~
- [ ] ~Documentation updated (not only docstrings)~
- [ ] Commits are squashed

**Post merge:**
- [ ] ~Create a tag~
- [ ] ~Check new version is pushed to PyPi after tag-triggered build is finished.~
- [ ] Delete working branch (if not needed anymore)
