### PR TITLE
update doc outline and extract how tos

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,17 +7,42 @@ edx-django-utils
 ===============================
 EdX utilities for Django Application development.
 
-Contents:
-
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
+   :caption: General Contents
 
-   readme
+   README <readme>
    getting_started
    testing
-   modules
+   Package Reference <modules>
    changelog
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Decisions
+
+   decisions/0001-purpose-of-this-repo
+   decisions/0002-extract-plugins-infrastructure-from-edx-platform
+   decisions/0003-logging-filters-for-user-and-ip
+   decisions/0004-public-api-and-app-organization
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Monitoring Decisions
+
+   monitoring/decisions/0001-monitoring-by-code-owner
+   monitoring/decisions/0002-custom-monitoring-language
+   monitoring/decisions/0003-code-owner-for-celery-tasks
+   monitoring/decisions/0004-code-owner-theme-and-squad
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Monitoring How-Tos
+
+   monitoring/how_tos/add_code_owner_custom_attribute_to_an_ida
+   monitoring/how_tos/using_custom_attributes
+   monitoring/how_tos/search_new_relic_nrql
+   monitoring/how_tos/update_monitoring_for_squad_or_theme_changes
 
 Indices and tables
 ==================
@@ -25,4 +50,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/monitoring/README.rst
+++ b/docs/monitoring/README.rst
@@ -1,0 +1,30 @@
+:orphan:
+
+This README explains the purpose of this directory in the form of a decision document.
+
+Context
+-------
+
+At this time, we don't have a standard way to pull in rst docs from outside of the main docs directory. See https://github.com/sphinx-doc/sphinx/issues/701 for details on this issue.
+
+Decision
+--------
+
+Copy monitoring/docs files to the main docs directory, and use an include statement as a quick temporary solution to publishing docs with the following benefits:
+
+* Original docs stay close to the code.
+* Any old github references to the old locations would still be accurate.
+* We may be able to implement a more automated solution in the future that doesn't break the new Readthedoc locations.
+
+Consequences
+------------
+
+New docs need to be copied to be included in the index.rst, which is only one minor additional step.
+
+Rejected Alternatives
+---------------------
+
+The following alternatives were temporarily rejected for the sake of expediency. The decision could be updated in more time were invested on this issue more globally.
+
+#. Move the monitoring/docs folder under the main docs folder. This would break existing references to github docs. Someone could choose to make this change in the future.
+#. Create sphinx plugin to automatically copy docs. This is a potentially good idea, but I am not investing in it at this time.

--- a/docs/monitoring/decisions/0001-monitoring-by-code-owner.rst
+++ b/docs/monitoring/decisions/0001-monitoring-by-code-owner.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../edx_django_utils/monitoring/docs/decisions/0001-monitoring-by-code-owner.rst

--- a/docs/monitoring/decisions/0002-custom-monitoring-language.rst
+++ b/docs/monitoring/decisions/0002-custom-monitoring-language.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../edx_django_utils/monitoring/docs/decisions/0002-custom-monitoring-language.rst

--- a/docs/monitoring/decisions/0003-code-owner-for-celery-tasks.rst
+++ b/docs/monitoring/decisions/0003-code-owner-for-celery-tasks.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../edx_django_utils/monitoring/docs/decisions/0003-code-owner-for-celery-tasks.rst

--- a/docs/monitoring/decisions/0004-code-owner-theme-and-squad.rst
+++ b/docs/monitoring/decisions/0004-code-owner-theme-and-squad.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../edx_django_utils/monitoring/docs/decisions/0004-code-owner-theme-and-squad.rst

--- a/docs/monitoring/how_tos/add_code_owner_custom_attribute_to_an_ida.rst
+++ b/docs/monitoring/how_tos/add_code_owner_custom_attribute_to_an_ida.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../edx_django_utils/monitoring/docs/how_tos/add_code_owner_custom_attribute_to_an_ida.rst

--- a/docs/monitoring/how_tos/search_new_relic_nrql.rst
+++ b/docs/monitoring/how_tos/search_new_relic_nrql.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../edx_django_utils/monitoring/docs/how_tos/search_new_relic_nrql.rst

--- a/docs/monitoring/how_tos/update_monitoring_for_squad_or_theme_changes.rst
+++ b/docs/monitoring/how_tos/update_monitoring_for_squad_or_theme_changes.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../edx_django_utils/monitoring/docs/how_tos/update_monitoring_for_squad_or_theme_changes.rst

--- a/docs/monitoring/how_tos/using_custom_attributes.rst
+++ b/docs/monitoring/how_tos/using_custom_attributes.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../edx_django_utils/monitoring/docs/how_tos/using_custom_attributes.rst

--- a/edx_django_utils/monitoring/docs/how_tos/add_code_owner_custom_attribute_to_an_ida.rst
+++ b/edx_django_utils/monitoring/docs/how_tos/add_code_owner_custom_attribute_to_an_ida.rst
@@ -83,30 +83,4 @@ If you are missing the ``code_owner`` custom attributes on a particular Transact
 Updating New Relic monitoring
 -----------------------------
 
-NRQL (New Relic Query Language) that uses the ``code_owner`` custom attributes (e.g. ``code_owner_squad``, ``code_owner_theme``, or ``code_owner``) may be found in alert conditions or dashboards.
-
-To change a squad or theme name, you should *expand* the NRQL before the change, and *contract* the NRQL after the change.
-
-Note: For edx.org, it is useful to wait a month before contracting the monitoring.
-
-Example expand phase NRQL::
-
-    code_owner_squad IN ('old-squad-name', 'new-squad-name')
-    code_owner_theme IN ('old-theme-name', 'new-theme-name')
-
-Example contract phase NRQL::
-
-    code_owner_squad = 'new-squad-name'
-    code_owner_theme = 'new-theme-name'
-
-To find the relevant NRQL to update, see `Searching New Relic NRQL`_.
-
-Searching New Relic NRQL
-------------------------
-
-The search script new_relic_nrql_search.py is generally useful for searching NRQL (New Relic Query Language) in New Relic. It searches the NRQL in New Relic alert policies (static alert conditions only), and in New Relic dashboards. Use ``--help`` for more details.
-
-The script can be especially useful for helping with the expand/contract phase when changing squad or theme names. For example, you could use the following::
-
-    new_relic_nrql_search.py --regex old-squad-name
-    new_relic_nrql_search.py --regex new-squad-name
+To update monitoring in the event of a squad or theme name change, see :doc:`update_monitoring_for_squad_or_theme_changes`.

--- a/edx_django_utils/monitoring/docs/how_tos/search_new_relic_nrql.rst
+++ b/edx_django_utils/monitoring/docs/how_tos/search_new_relic_nrql.rst
@@ -1,0 +1,6 @@
+Searching New Relic NRQL
+========================
+
+The search script `new_relic_nrql_search.py`_ is generally useful for searching NRQL (New Relic Query Language) in New Relic. It searches the NRQL in New Relic alert policies, and in New Relic dashboards. Use ``--help`` for more details.
+
+.. _new_relic_nrql_search.py: https://github.com/edx/edx-django-utils/blob/master/edx_django_utils/monitoring/scripts/new_relic_nrql_search.py

--- a/edx_django_utils/monitoring/docs/how_tos/update_monitoring_for_squad_or_theme_changes.rst
+++ b/edx_django_utils/monitoring/docs/how_tos/update_monitoring_for_squad_or_theme_changes.rst
@@ -1,0 +1,44 @@
+Update Monitoring for Squad or Theme Changes
+============================================
+
+.. contents::
+   :local:
+   :depth: 2
+
+Understanding code owner custom attributes
+------------------------------------------
+
+If you first need some background on the ``code_owner_squad`` and ``code_owner_theme`` custom attributes, see :doc:`add_code_owner_custom_attribute_to_an_ida`.
+
+Expand and contract name changes
+--------------------------------
+
+NRQL (New Relic Query Language) statements that use the ``code_owner_squad`` or ``code_owner_theme`` (or ``code_owner``) custom attributes may be found in alert conditions or dashboards.
+
+To change a squad or theme name, you should *expand* the NRQL before the change, and *contract* the NRQL after the change.
+
+.. note::
+
+    For edx.org, it is useful to wait a month before implementing the contract phase of the monitoring update.
+
+Example expand phase NRQL::
+
+    code_owner_squad IN ('old-squad-name', 'new-squad-name')
+    code_owner_theme IN ('old-theme-name', 'new-theme-name')
+
+Example contract phase NRQL::
+
+    code_owner_squad = 'new-squad-name'
+    code_owner_theme = 'new-theme-name'
+
+To find the relevant NRQL to update, see `Searching New Relic NRQL`_.
+
+Searching New Relic NRQL
+------------------------
+
+See :doc:`search_new_relic_nrql` for general information about the ``new_relic_nrql_search.py`` script.
+
+This script can be especially useful for helping with the expand/contract phase when changing squad or theme names. For example, you could use the following::
+
+    new_relic_nrql_search.py --regex old-squad-name
+    new_relic_nrql_search.py --regex new-squad-name

--- a/edx_django_utils/monitoring/docs/how_tos/using_custom_attributes.rst
+++ b/edx_django_utils/monitoring/docs/how_tos/using_custom_attributes.rst
@@ -3,7 +3,7 @@ Enhanced Monitoring and Custom Attributes
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 What is a Custom Attribute?
 ---------------------------


### PR DESCRIPTION
**Description:**

*docs: update published doc outline*
    
Updates the doc index to provide some minor enhancements, and to include the monitoring decisions and how-tos.
    
See docs/monitoring/README.rst for the decision on how these docs were included.

Here is a screenshot of the new outline:
<img width="961" alt="Screen Shot 2021-05-17 at 3 49 09 PM" src="https://user-images.githubusercontent.com/14576445/118547798-8b15c780-b727-11eb-8a6e-a749ae440dec.png">

*docs: refactor squad and theme name change how to*
    
Extracts the following new how tos:
- search_new_relic_nrql.rst
- update_monitoring_for_squad_or_theme_changes.rst

**Author concerns:**

I'm uncertain about how I included the monitoring docs in the outline, but I didn't wanted to be blocked and I wanted to be able to point to these docs from the runbook.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
