### PR TITLE
fix: NRQL search script using updated api

### DIFF
--- a/edx_django_utils/monitoring/scripts/new_relic_nrql_search.py
+++ b/edx_django_utils/monitoring/scripts/new_relic_nrql_search.py
@@ -2,13 +2,17 @@
 This script takes a regex to search through the NRQL of New Relic alert policies
 and New dashboards.
 
+This script makes use of New Relic's GraphQL API. See https://api.newrelic.com/graphiql.
+
 For help::
 
     python edx_django_utils/monitoring/scripts/new_relic_nrql_search.py --help
 
 """
+import json
 import os
 import re
+from string import Template
 
 import click
 import requests
@@ -22,17 +26,15 @@ import requests
 )
 @click.option(
     '--policy_id',
-    type=int,
     multiple=True,
     help="Optionally provide a specific policy id to check. Multiple can be supplied.",
 )
 @click.option(
-    '--dashboard_id',
-    type=int,
+    '--dashboard_guid',
     multiple=True,
-    help="Optionally provide a specific dashboard id to check. Multiple can be supplied.",
+    help="Optionally provide a specific dashboard guid to check. Multiple can be supplied.",
 )
-def main(regex, policy_id, dashboard_id):
+def main(regex, policy_id, dashboard_guid):
     """
     Search NRQL in New Relic alert policies and dashboards using regex.
 
@@ -44,68 +46,148 @@ def main(regex, policy_id, dashboard_id):
 
     Pre-requisite, set the following environment variable (in a safe way):
 
-    NEW_RELIC_API_KEY=XXXXXXX
+        NEW_RELIC_API_KEY=XXXXXXX
 
     See https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#user-api-key for details
     on setting an API key.
 
-    To skip alert policies or dashboards, just use a non-existent id, like --policy_id 0 or --dashboard_id 0.
+    To skip alert policies or dashboards, just use a non-existent id, like --policy_id 0 or --dashboard_guid 0.
 
-    WARNING: NRQL Baseline alert conditions can't be searched. See
-    https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/rest-api-calls-alerts/#excluded
     """
     # Set environment variables
     api_key = os.environ['NEW_RELIC_API_KEY']
-    headers = {"X-Api-Key": api_key}
+    headers = {
+        "Content-Type": "application/json",
+        "X-Api-Key": api_key,
+    }
+
     compiled_regex = re.compile(regex)
 
-    audit_alert_policies(compiled_regex, headers, policy_id)
+    account_ids = get_account_ids(headers)
+    for account_id in account_ids:
+        search_alert_policies(compiled_regex, account_id, headers, policy_id)
     print()
-    audit_dashboards(compiled_regex, dashboard_id, headers)
+    search_dashboards(compiled_regex, headers, dashboard_guid)
     print(flush=True)
 
 
-def audit_alert_policies(regex, headers, policy_id):
+def get_account_ids(headers):
+    """
+    Returns a list of the New Relic account ids to be searched.
+    """
+    response = requests.get(
+        'https://api.newrelic.com/graphql',
+        headers=headers,
+        params={'query': """
+            {
+              actor {
+                accounts {
+                  id
+                }
+              }
+            }
+        """},
+    )
+    response.raise_for_status()  # could be an error response
+    response_data = response.json()
+    account_ids = [account['id'] for account in response_data['data']['actor']['accounts']]
+    return account_ids
+
+
+# Template with variables:
+# - account_id
+# - cursor; can be null or cursor string
+ALERT_POLICY_LIST_TEMPLATE = Template("""
+    {
+      actor {
+        account(id: ${account_id}) {
+          alerts {
+            policiesSearch(cursor: ${cursor}) {
+              policies {
+                id
+                name
+              }
+              nextCursor
+            }
+          }
+        }
+      }
+    }
+""")
+
+# Template with variables:
+# - account_id
+# - policy_id
+NRQL_ALERT_CONDITIONS_TEMPLATE = Template("""
+    {
+      actor {
+        account(id: ${account_id}) {
+          alerts {
+            nrqlConditionsSearch(searchCriteria: {policyId: ${policy_id}}) {
+              nrqlConditions {
+                nrql {
+                  query
+                }
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+""")
+
+
+def search_alert_policies(regex, account_id, headers, policy_id):
     """
     Searches New Relic alert policy NRQL using the regex argument.
 
     Arguments:
         regex (re.Pattern): compiled regex used to compare against NRQL
+        account_id (int): the id of the New Relic account in which to search.
+        headers (dict): headers required to make http requests to New Relic.
         policy_id (tuple): optional tuple of policy ids supplied from the command-line.
-        headers (dict): headers required to make http requests to New Relic
     """
     policies = []
-    page = 1
+    cursor = 'null'
     while True:
         response = requests.get(
-            'https://api.newrelic.com/v2/alerts_policies.json',
+            'https://api.newrelic.com/graphql',
             headers=headers,
-            params={'page': page},
+            params={'query': ALERT_POLICY_LIST_TEMPLATE.substitute(
+                account_id=account_id,
+                cursor=cursor
+            )},
         )
         response.raise_for_status()  # could be an error response
         response_data = response.json()
-        if not response_data['policies']:
+        query_results = response_data['data']['actor']['account']['alerts']['policiesSearch']
+        policies += query_results['policies']
+        if not query_results['nextCursor']:
             break
-        policies += response_data['policies']
-        page += 1
+        cursor = f"\"{query_results['nextCursor']}\""
     # Note: policy_id is an optional tuple of policy ids supplied from the command-line.
     if policy_id:
         policies = [policy for policy in policies if policy['id'] in policy_id]
-    print(f"Searching for regex {regex.pattern} in {len(policies)} alert policies...")
+    print(f"Searching for regex {regex.pattern} in {len(policies)} alert policies in account {account_id}...")
     policy_ids_printed = {}
     for policy in policies:
         print('.', end='', flush=True)
 
-        # get the (static) NRQL alert conditions from the alert policy
+        # get the NRQL alert conditions from the alert policy
         response = requests.get(
-            'https://api.newrelic.com/v2/alerts_nrql_conditions.json',
+            'https://api.newrelic.com/graphql',
             headers=headers,
-            params={'policy_id': policy['id']},
+            params={'query': NRQL_ALERT_CONDITIONS_TEMPLATE.substitute(
+                account_id=account_id,
+                policy_id=policy['id'],
+            )},
         )
         response.raise_for_status()  # could be an error response
         response_data = response.json()
 
-        for nrql_condition in response_data['nrql_conditions']:
+        nrql_conditions = response_data['data']['actor']['account']['alerts']['nrqlConditionsSearch']['nrqlConditions']
+        for nrql_condition in nrql_conditions:
             nrql_query = nrql_condition['nrql']['query']
             if regex.search(nrql_query, re.IGNORECASE):
 
@@ -113,7 +195,7 @@ def audit_alert_policies(regex, headers, policy_id):
                 if policy['id'] not in policy_ids_printed:
                     policy_ids_printed[policy['id']] = True
                     print('\n')
-                    print(f"Found in {policy['id']}: {policy['name']}:")
+                    print(f"Found in \"{policy['name']}\" (policy_id={policy['id']}):")
                     print('')
 
                 # Print the alert condition that matched
@@ -127,76 +209,122 @@ def audit_alert_policies(regex, headers, policy_id):
     else:
         print("\n\nNo alert policies matched.")
 
-    print(
-        "\nWARNING: NRQL Baseline alert conditions can't be searched. See "
-        "https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/"
-        "rest-api-calls-alerts/#excluded"
-    )
+
+# Template with variable cursor; can be null or cursor string
+DASHBOARD_LIST_QUERY_TEMPLATE = Template("""
+    {
+      actor {
+        entitySearch(queryBuilder: {type: DASHBOARD}) {
+          results(cursor: ${cursor}) {
+            entities {
+              ... on DashboardEntityOutline {
+                guid
+                name
+                accountId
+              }
+            }
+            nextCursor
+          }
+          count
+        }
+      }
+    }
+""")
+
+DASHBOARD_ENTITY_QUERY = """
+    query ($guids: EntityGuid!) {
+      actor {
+        entities(guids: $guids) {
+          ... on DashboardEntity {
+            guid
+            pages {
+              widgets {
+                rawConfiguration
+                title
+              }
+            }
+            name
+          }
+        }
+      }
+    }
+"""
 
 
-def audit_dashboards(regex, dashboard_id, headers):
+def search_dashboards(regex, headers, dashboard_guid):
     """
     Searches New Relic alert policy NRQL using the regex argument.
 
     Arguments:
         regex (re.Pattern): compiled regex used to compare against NRQL
-        dashboard_id (tuple): optional tuple of dashboard ids supplied from the command-line.
         headers (dict): headers required to make http requests to New Relic
+        dashboard_guid (tuple): optional tuple of dashboard guids supplied from the command-line.
     """
     # load details of all dashboards
     dashboards = []
-    page = 1
+    cursor = 'null'
     while True:
         response = requests.get(
-            'https://api.newrelic.com/v2/dashboards.json',
+            'https://api.newrelic.com/graphql',
             headers=headers,
-            params={'page': page},
+            params={'query': DASHBOARD_LIST_QUERY_TEMPLATE.substitute(cursor=cursor)},
         )
         response.raise_for_status()  # could be an error response
         response_data = response.json()
-        if not response_data['dashboards']:
+        query_results = response_data['data']['actor']['entitySearch']['results']
+        dashboards += query_results['entities']
+        if not query_results['nextCursor']:
             break
-        dashboards += response_data['dashboards']
-        page += 1
-    # Note: dashboard_id is an optional tuple of dashboard ids supplied from the command-line.
-    if dashboard_id:
-        dashboards = [dashboard for dashboard in dashboards if dashboard['id'] in dashboard_id]
+        cursor = f"\"{query_results['nextCursor']}\""
+    # Note: dashboard_guid is an optional tuple of dashboard guids supplied from the command-line.
+    if dashboard_guid:
+        dashboards = [dashboard for dashboard in dashboards if dashboard['guid'] in dashboard_guid]
     print(f"Searching for regex {regex.pattern} in {len(dashboards)} dashboards...")
-    dashboard_ids_printed = {}
+    dashboard_guids_printed = {}
     for dashboard in dashboards:
         print('.', end='', flush=True)
 
         # get the dashboard details
         response = requests.get(
-            f"https://api.newrelic.com/v2/dashboards/{dashboard['id']}.json",
+            'https://api.newrelic.com/graphql',
             headers=headers,
+            params={
+                'query': DASHBOARD_ENTITY_QUERY,
+                'variables': json.dumps({'guids': dashboard['guid']}),
+            }
         )
         response.raise_for_status()  # could be an error response
         response_data = response.json()
 
-        for widget in response_data['dashboard']['widgets']:
-            for data in widget['data']:
+        if 'errors' in response_data:
+            # compensates for a bug where some (soft-deleted?) dashboards can't be found
+            if 'No dashboard entity found' in response_data['errors'][0]['message']:
+                continue
+            print(f"Unexpected errors: {response_data['errors']}")
 
-                if 'nrql' not in data:
+        for page in response_data['data']['actor']['entities'][0]['pages']:
+            for widget in page['widgets']:
+                if 'nrqlQueries' not in widget['rawConfiguration']:
                     continue
 
-                nrql_query = data['nrql']
-                if regex.search(nrql_query, re.IGNORECASE):
+                for nrql_query in widget['rawConfiguration']['nrqlQueries']:
+                    query = nrql_query['query']
+                    if regex.search(query, re.IGNORECASE):
 
-                    # Print the dashboard header for the first widget nrql that matches
-                    if dashboard['id'] not in dashboard_ids_printed:
-                        dashboard_ids_printed[dashboard['id']] = True
-                        print('\n')
-                        print(f"Found in {dashboard['id']}: {dashboard['title']}:")
-                        print('')
+                        # Print the dashboard header for the first widget nrql that matches
+                        if dashboard['guid'] not in dashboard_guids_printed:
+                            dashboard_guids_printed[dashboard['guid']] = True
+                            print('\n')
+                            print(f"Found in \"{dashboard['name']}\" (guid={dashboard['guid']}):")
+                            print('')
 
-                    # Print the widget NRQL that matches
-                    print(f"- {widget['presentation']['title']}: {nrql_query}")
+                        # Print the widget NRQL that matches
+                        print(f"- {widget['title']}: {query}")
 
-    if dashboard_ids_printed:
+    if dashboard_guids_printed:
         command_line = ''
-        for dashboard_id in dashboard_ids_printed.keys():
-            command_line += f'--dashboard_id {dashboard_id} '
+        for dashboard_guid in dashboard_guids_printed.keys():
+            command_line += f'--dashboard_guid {dashboard_guid} '
         print("\n\nRun again with found dashboards: {}".format(command_line))
     else:
         print("\n\nNo dashboards found that match.")


### PR DESCRIPTION
**Description:**

The original search script was using the New Relic REST API
v2, which has gaps and bugs. It was not clearly documented
that the preferred method is to use the new GraphQL API.

The script has been updated to use the new GraphQL API.

Note: it may make sense to introduce Graphene, or some other
library to work with GraphQL, but to start I avoided adding
a new dependency and was able to use New Relic's GUI to play
with different queries here:
https://api.newrelic.com/graphiql

**Testing instructions:**

Was tested locally with the following:
```
python edx_django_utils/monitoring/scripts/new_relic_nrql_search.py --regex "'(arch|platform-arch)'"

python edx_django_utils/monitoring/scripts/new_relic_nrql_search.py --regex "'(arch|platform-arch)'" --policy_id 1148306 --policy_id 1160889 --policy_id 1160905 --dashboard_guid ODgxNzh8VklafERBU0hCT0FSRHwxMjI3MDI3 --dashboard_guid ODgxNzh8VklafERBU0hCT0FSRHwxNDI2ODEw
```

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed