### PR TITLE
feat: Add read-only mixin for a custom Django admin class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ----------
 
+[4.1.0] - 2021-06-01
+--------------------
+
+Added
+_______
+
+* Added mixin for a custom Django admin class which disables CRUD operation on the admin's model.
+
 Added
 _______
 

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "4.0.0"
+__version__ = "4.1.0"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/admin/mixins.py
+++ b/edx_django_utils/admin/mixins.py
@@ -1,0 +1,35 @@
+"""
+Mixins for use in Django Admin classes.
+"""
+
+
+class ReadOnlyAdminMixin:
+    """
+    Disables all editing capabilities for the admin's model.
+    An example usage: a Django proxy model which provides data to perform some other action.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.list_display_links = None
+        self.readonly_fields = [f.name for f in self.model._meta.get_fields()]
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        if 'delete_selected' in actions:
+            del actions["delete_selected"]  # pragma: no cover
+        return actions
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_delete_permission(self, request, obj=None):  # pylint: disable=unused-argument
+        return False
+
+    def save_model(self, request, obj, form, change):
+        pass  # pragma: no cover
+
+    def delete_model(self, request, obj):
+        pass  # pragma: no cover
+
+    def save_related(self, request, form, formsets, change):
+        pass  # pragma: no cover

--- a/edx_django_utils/admin/tests/models.py
+++ b/edx_django_utils/admin/tests/models.py
@@ -1,0 +1,10 @@
+from django.db import models
+
+
+class GenericModel(models.Model):
+    name = models.CharField(max_length=100)
+    description = models.TextField()
+    created = models.DateField()
+
+    class Meta:
+        ordering = ('name',)

--- a/edx_django_utils/admin/tests/test_mixins.py
+++ b/edx_django_utils/admin/tests/test_mixins.py
@@ -1,0 +1,52 @@
+"""
+Tests for admin mixins.
+"""
+import pytest
+from django.contrib.admin import ModelAdmin
+from django.contrib.admin.sites import AdminSite
+
+from edx_django_utils.admin.mixins import ReadOnlyAdminMixin
+from edx_django_utils.admin.tests.models import GenericModel
+
+
+class ReadOnlyAdmin(ReadOnlyAdminMixin, ModelAdmin):
+    """
+    Test admin interface which adds the mixin to be tested.
+    """
+    pass
+
+
+@pytest.fixture
+def site():
+    return AdminSite()
+
+
+@pytest.fixture
+def a_request():
+    class MockRequest:
+        GET = []
+    return MockRequest()
+
+
+@pytest.fixture
+def read_only_admin(site):
+    return ReadOnlyAdmin(GenericModel, site)
+
+
+class TestReadOnlyAdminMixin:
+    def test_create(self, read_only_admin, a_request):
+        assert not read_only_admin.has_add_permission(a_request)
+
+    def test_delete(self, read_only_admin, a_request):
+        assert not read_only_admin.has_delete_permission(a_request)
+
+    def test_delete_action(self, read_only_admin, a_request):
+        actions = read_only_admin.get_actions(a_request)
+        assert 'delete_selected' not in actions
+
+    def test_list_display_links(self, read_only_admin):
+        assert read_only_admin.list_display_links is None
+
+    def test_read_only_fields(self, read_only_admin):
+        # The GenericModel has three fields plus an Django-added id field - ensure *all* are marked as read-only.
+        assert len(read_only_admin.readonly_fields) == 4

--- a/test_settings.py
+++ b/test_settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = (
     "django.contrib.contenttypes",
     "waffle",
     "edx_django_utils",
+    "edx_django_utils.admin.tests",
 )
 
 LOCALE_PATHS = [root("edx_django_utils", "conf", "locale")]


### PR DESCRIPTION
**Description:**

The mixin disables CRUD operations on the admin's model. This type of mixin is currently used in an edx-platform Django proxy model, used for invoking actions on certain course keys - but without modifying the proxied model.

Bump version to 4.1.0 for release.

**JIRA:**

https://openedx.atlassian.net/browse/TNL-8080

**Reviewers:**
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
