### PR TITLE
BOM-2745: Add DeploymentMonitoringMiddleware

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ----------
 
+[4.4.0] - 2021-09-02
+--------------------
+
+Added
+_______
+
+* Added ``DeploymentMonitoringMiddleware`` to record ``Python`` and ``Django`` versions in NewRelic with each transaction.
+
 [4.3.0] - 2021-07-20
 --------------------
 

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "4.3.0"
+__version__ = "4.4.0"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/README.rst
+++ b/edx_django_utils/monitoring/README.rst
@@ -20,6 +20,7 @@ Here is how you add the middleware:
 .. code-block::
 
     MIDDLEWARE = (
+        'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',
         'edx_django_utils.cache.middleware.RequestCacheMiddleware',
         # Generate code ownership attributes. Keep this immediately after RequestCacheMiddleware.
         ...

--- a/edx_django_utils/monitoring/__init__.py
+++ b/edx_django_utils/monitoring/__init__.py
@@ -9,7 +9,11 @@ from .internal.code_owner.utils import (
     set_code_owner_attribute,
     set_code_owner_attribute_from_module
 )
-from .internal.middleware import CachedCustomMonitoringMiddleware, MonitoringMemoryMiddleware
+from .internal.middleware import (
+    CachedCustomMonitoringMiddleware,
+    DeploymentMonitoringMiddleware,
+    MonitoringMemoryMiddleware
+)
 from .internal.transactions import (
     function_trace,
     get_current_transaction,

--- a/edx_django_utils/monitoring/tests/test_monitoring.py
+++ b/edx_django_utils/monitoring/tests/test_monitoring.py
@@ -1,7 +1,8 @@
 """
 Tests for custom monitoring.
 """
-from unittest.mock import call, patch
+import re
+from unittest.mock import Mock, call, patch
 
 import ddt
 from django.test import TestCase
@@ -9,6 +10,7 @@ from django.test import TestCase
 from edx_django_utils.cache import RequestCache
 from edx_django_utils.monitoring import (
     CachedCustomMonitoringMiddleware,
+    DeploymentMonitoringMiddleware,
     accumulate,
     get_current_transaction,
     increment,
@@ -149,3 +151,37 @@ class TestCustomMonitoringMiddleware(TestCase):
     def test_record_exception(self, mock_record_exception):
         record_exception()
         mock_record_exception.assert_called_once()
+
+
+class TestDeploymentMonitoringMiddleware(TestCase):
+    """
+    Test the DeploymentMonitoringMiddleware functionalities
+    """
+    version_pattern = r'\d+(\.\d+){2}'
+
+    def setUp(self):
+        super().setUp()
+        RequestCache.clear_all_namespaces()
+
+    def _test_key_value_pair(self, function_call, key):
+        """
+        Asserts the function call key and value with the provided key and the default version_pattern
+        """
+        attribute_key, attribute_value = function_call[0]
+        assert attribute_key == key
+        assert re.match(re.compile(self.version_pattern), attribute_value)
+
+    @patch('newrelic.agent')
+    def test_record_python_and_django_version(self, mock_newrelic_agent):
+        """
+        Test that the DeploymentMonitoringMiddleware records the correct Python and Django versions
+        """
+        middleware = DeploymentMonitoringMiddleware(Mock())
+        middleware(Mock())
+
+        parameter_calls_count = mock_newrelic_agent.add_custom_parameter.call_count
+        assert parameter_calls_count == 2
+
+        function_calls = mock_newrelic_agent.add_custom_parameter.call_args_list
+        self._test_key_value_pair(function_calls[0], 'python_version')
+        self._test_key_value_pair(function_calls[1], 'django_version')


### PR DESCRIPTION
**Issue:** [BOM-2745](https://openedx.atlassian.net/browse/BOM-2745)

### Description
- Added `DeploymentMonitoringMiddleware` in monitoring middlewares to save `Python` and `Django` versions as custom attributes in `NewRelic` events.