### PR TITLE
chore: Replace deprecated 'django.conf.urls.url'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ----------
 
+[4.4.1] - 2021-12-17
+--------------------
+
+Updated
+_______
+
+* Replaced usage of 'django.conf.urls.url()' with 'django.urls.re_path()'
+
 [4.4.0] - 2021-09-02
 --------------------
 

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "4.4.0"
+__version__ = "4.4.1"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/tests/code_owner/test_middleware.py
+++ b/edx_django_utils/monitoring/tests/code_owner/test_middleware.py
@@ -5,8 +5,8 @@ from unittest import TestCase
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import ddt
-from django.conf.urls import url
 from django.test import RequestFactory, override_settings
+from django.urls import re_path
 from django.views.generic import View
 
 from edx_django_utils.monitoring import CodeOwnerMonitoringMiddleware
@@ -20,8 +20,8 @@ class MockMiddlewareViewTest(View):
 
 
 urlpatterns = [
-    url(r'^middleware-test/$', MockMiddlewareViewTest.as_view()),
-    url(r'^test/$', MockViewTest.as_view()),
+    re_path(r'^middleware-test/$', MockMiddlewareViewTest.as_view()),
+    re_path(r'^test/$', MockViewTest.as_view()),
 ]
 
 SET_CUSTOM_ATTRIBUTE_MOCK = MagicMock()

--- a/edx_django_utils/plugins/plugin_urls.py
+++ b/edx_django_utils/plugins/plugin_urls.py
@@ -5,7 +5,8 @@ Please remember to expose any new public methods in the `__init__.py` file.
 """
 from logging import getLogger
 
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import re_path
 
 from . import constants, registry, utils
 
@@ -21,9 +22,9 @@ def _get_url(url_module_path, url_config):
     regex = url_config.get(constants.PluginURLs.REGEX, r"")
 
     if namespace:
-        return url(regex, include((url_module_path, app_name), namespace=namespace))
+        return re_path(regex, include((url_module_path, app_name), namespace=namespace))
     else:
-        return url(regex, include(url_module_path))
+        return re_path(regex, include(url_module_path))
 
 
 def get_plugin_url_patterns(project_type):


### PR DESCRIPTION
'django.conf.urls.url' has been deprecated in Django 3 in favour of 'django.urls.re_path'